### PR TITLE
Add aliases to arithmetic expressions

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -482,7 +482,7 @@ named!(pub table_list<&[u8], Vec<Table> >,
 /// Integer literal value
 named!(pub integer_literal<&[u8], Literal>,
     chain!(
-        val: delimited!(opt!(multispace), digit, opt!(multispace)),
+        val: digit,
         || {
             let intval = i64::from_str(str::from_utf8(val).unwrap()).unwrap();
             Literal::Integer(intval)

--- a/src/common.rs
+++ b/src/common.rs
@@ -493,13 +493,10 @@ named!(pub integer_literal<&[u8], Literal>,
 /// String literal value
 named!(pub string_literal<&[u8], Literal>,
     chain!(
-        val: delimited!(opt!(multispace),
-                 alt_complete!(
-                       delimited!(tag!("\""), opt!(take_until!("\"")), tag!("\""))
-                     | delimited!(tag!("'"), opt!(take_until!("'")), tag!("'"))
-                 ),
-                 opt!(multispace)
-              ),
+        val: alt_complete!(
+            delimited!(tag!("\""), opt!(take_until!("\"")), tag!("\""))
+            | delimited!(tag!("'"), opt!(take_until!("'")), tag!("'"))
+        ),
         || {
             let val = val.unwrap_or("".as_bytes());
             let s = String::from(str::from_utf8(val).unwrap());

--- a/src/condition.rs
+++ b/src/condition.rs
@@ -143,43 +143,47 @@ named!(boolean_primary<&[u8], ConditionExpression>,
 
 
 named!(predicate<&[u8], ConditionExpression>,
-    alt_complete!(
-            chain!(
-                delimited!(opt!(multispace), tag!("?"), opt!(multispace)),
-                || {
-                    ConditionExpression::Base(
-                        ConditionBase::Placeholder
-                    )
-                }
-            )
-        |   chain!(
-                field: integer_literal,
-                || {
-                    ConditionExpression::Base(ConditionBase::Literal(field))
-                }
-            )
-        |   chain!(
-                field: string_literal,
-                || {
-                    ConditionExpression::Base(ConditionBase::Literal(field))
-                }
-            )
-        |   chain!(
-                field: delimited!(opt!(multispace), column_identifier, opt!(multispace)),
-                || {
-                    ConditionExpression::Base(
-                        ConditionBase::Field(field)
-                    )
-                }
-            )
-        |   chain!(
-                select: delimited!(tag!("("), nested_selection, tag!(")")),
-                || {
-                    ConditionExpression::Base(
-                        ConditionBase::NestedSelect(Box::new(select))
-                    )
-                }
-            )
+    delimited!(
+        opt!(multispace),
+        alt_complete!(
+                chain!(
+                    tag!("?"),
+                    || {
+                        ConditionExpression::Base(
+                            ConditionBase::Placeholder
+                        )
+                    }
+                )
+            |   chain!(
+                    field: integer_literal,
+                    || {
+                        ConditionExpression::Base(ConditionBase::Literal(field))
+                    }
+                )
+            |   chain!(
+                    field: string_literal,
+                    || {
+                        ConditionExpression::Base(ConditionBase::Literal(field))
+                    }
+                )
+            |   chain!(
+                    field: column_identifier,
+                    || {
+                        ConditionExpression::Base(
+                            ConditionBase::Field(field)
+                        )
+                    }
+                )
+            |   chain!(
+                    select: delimited!(tag!("("), nested_selection, tag!(")")),
+                    || {
+                        ConditionExpression::Base(
+                            ConditionBase::NestedSelect(Box::new(select))
+                        )
+                    }
+                )
+        ),
+        opt!(multispace)
     )
 );
 


### PR DESCRIPTION
I removed `multispace` matching from `string_literal` and `integer_literal` since it swallowed the whitespace needed in `as_alias` (and it also seemed reasonable to do this at a higher level than in the literal matchers itself, but let me know if you disagree).

It seemed like the only change needed to do so was to add whitespace matching to `predicate` instead, which it already had for some of the branches. 

I'll send a separate PR to add alias support for literals as well.