### PR TITLE
Remove verbose-errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,4 +6,4 @@ authors = ["Malte Schwarzkopf <malte@csail.mit.edu>"]
 [dependencies]
 serde = "1.0"
 serde_derive = "1.0"
-nom = { version = "^3.2.1", features = ["verbose-errors"] }
+nom = "^3.2.1"


### PR DESCRIPTION
I must've thought we needed this while upgrading, but from testing it doesn't seem like we do! @ms705: I agree with what you said in https://github.com/ms705/nom-sql/pull/13#issuecomment-368084612 though, we should try to propagate errors back at some point.