### PR TITLE
Support auto_increment in table options

### DIFF
--- a/src/create.rs
+++ b/src/create.rs
@@ -372,6 +372,19 @@ named!(pub creation<&[u8], CreateTableStatement>,
         opt!(
             complete!(
                 do_parse!(
+                    tag_no_case!("auto_increment") >>
+                    opt_multispace >>
+                    tag!("=") >>
+                    opt_multispace >>
+                    integer_literal >>
+                    ()
+                )
+            )
+        ) >>
+        opt_multispace >>
+        opt!(
+            complete!(
+                do_parse!(
                     tag_no_case!("default charset") >>
                     opt_multispace >>
                     tag!("=") >>

--- a/tests/autoincrement.txt
+++ b/tests/autoincrement.txt
@@ -1,0 +1,7 @@
+CREATE TABLE `postcode_city` (
+  `id` int(10) unsigned NOT NULL AUTO_INCREMENT COMMENT 'Id',
+  `country_code` varchar(5) NOT NULL COMMENT 'Country Code',
+  `postcode` varchar(20) NOT NULL COMMENT 'Postcode',
+  `city` text NOT NULL COMMENT 'City',
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB AUTO_INCREMENT=52142 DEFAULT CHARSET=utf8 COMMENT='Postcode -> City';

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -174,3 +174,12 @@ fn parse_comments() {
     assert_eq!(ok, 2);
     assert_eq!(fail, 0);
 }
+
+#[test]
+fn parse_autoincrement() {
+    let (ok, fail) = parse_file("tests/autoincrement.txt");
+
+    // There is 1 CREATE TABLE queries in the schema
+    assert_eq!(ok, 1);
+    assert_eq!(fail, 0);
+}


### PR DESCRIPTION
Note that this is still order dependent and will fail
if the options are ordered differently from what the parser
expects.