### PR TITLE
Upgrade to nom v4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ license = "MIT"
 [dependencies]
 serde = "1.0"
 serde_derive = "1.0"
-nom = "^3.2.1"
+nom = "^4.2.0"
 
 [dev-dependencies]
 pretty_assertions = "0.5.1"

--- a/src/create_table_options.rs
+++ b/src/create_table_options.rs
@@ -1,11 +1,12 @@
 use nom::{alphanumeric, multispace};
+use nom::types::CompleteByteSlice;
 
 use common::{
     integer_literal, opt_multispace, sql_identifier, string_literal,
 };
 
-named!(pub table_options<()>, do_parse!(
-       separated_list_complete!(table_options_separator, create_option)
+named!(pub table_options<CompleteByteSlice, ()>, do_parse!(
+       separated_list!(table_options_separator, create_option)
         >>
         (
             // TODO: make the create options accessible
@@ -13,8 +14,8 @@ named!(pub table_options<()>, do_parse!(
         )
 ));
 
-named!(table_options_separator<()>, do_parse!(
-    alt_complete!(
+named!(table_options_separator<CompleteByteSlice, ()>, do_parse!(
+    alt!(
         map!(multispace, |_| ()) |
         do_parse!(
             opt_multispace >>
@@ -25,7 +26,7 @@ named!(table_options_separator<()>, do_parse!(
     ) >> ()
 ));
 
-named!(create_option<()>, alt_complete!(
+named!(create_option<CompleteByteSlice, ()>, alt!(
         create_option_type |
         create_option_pack_keys |
         create_option_engine |
@@ -39,7 +40,7 @@ named!(create_option<()>, alt_complete!(
         create_option_key_block_size
 ));
 
-named!(create_option_type<()>, complete!(
+named!(create_option_type<CompleteByteSlice, ()>,
     do_parse!(
         tag_no_case!("type") >>
         opt_multispace >>
@@ -48,20 +49,20 @@ named!(create_option_type<()>, complete!(
         alphanumeric >>
         ()
     )
-));
+);
 
-named!(create_option_pack_keys<()>, complete!(
+named!(create_option_pack_keys<CompleteByteSlice, ()>,
     do_parse!(
         tag_no_case!("pack_keys") >>
         opt_multispace >>
         tag!("=") >>
         opt_multispace >>
-        alt_complete!(tag!("0") | tag!("1")) >>
+        alt!(tag!("0") | tag!("1")) >>
         ()
     )
-));
+);
 
-named!(create_option_engine<()>, complete!(
+named!(create_option_engine<CompleteByteSlice, ()>,
     do_parse!(
         tag_no_case!("engine") >>
         opt_multispace >>
@@ -70,9 +71,9 @@ named!(create_option_engine<()>, complete!(
         opt!(alphanumeric) >>
         ()
     )
-));
+);
 
-named!(create_option_auto_increment<()>, complete!(
+named!(create_option_auto_increment<CompleteByteSlice, ()>,
     do_parse!(
         tag_no_case!("auto_increment") >>
         opt_multispace >>
@@ -81,15 +82,15 @@ named!(create_option_auto_increment<()>, complete!(
         integer_literal >>
         ()
     )
-));
+);
 
-named!(create_option_default_charset<()>, complete!(
+named!(create_option_default_charset<CompleteByteSlice, ()>,
     do_parse!(
         tag_no_case!("default charset") >>
         opt_multispace >>
         tag!("=") >>
         opt_multispace >>
-        alt_complete!(
+        alt!(
             tag!("utf8mb4") |
             tag!("utf8") |
             tag!("binary") |
@@ -99,9 +100,9 @@ named!(create_option_default_charset<()>, complete!(
             ) >>
         ()
     )
-));
+);
 
-named!(create_option_collate<()>, complete!(
+named!(create_option_collate<CompleteByteSlice, ()>,
     do_parse!(
         tag_no_case!("collate") >>
         opt_multispace >>
@@ -111,9 +112,9 @@ named!(create_option_collate<()>, complete!(
         sql_identifier >>
         ()
     )
-));
+);
 
-named!(create_option_comment<()>, complete!(
+named!(create_option_comment<CompleteByteSlice, ()>,
     do_parse!(
         tag_no_case!("comment") >>
         opt_multispace >>
@@ -122,9 +123,9 @@ named!(create_option_comment<()>, complete!(
         string_literal >>
         ()
     )
-));
+);
 
-named!(create_option_max_rows<()>, complete!(
+named!(create_option_max_rows<CompleteByteSlice, ()>,
     do_parse!(
         tag_no_case!("max_rows") >>
         opt_multispace >>
@@ -133,9 +134,9 @@ named!(create_option_max_rows<()>, complete!(
         integer_literal >>
         ()
     )
-));
+);
 
-named!(create_option_avg_row_length<()>, complete!(
+named!(create_option_avg_row_length<CompleteByteSlice, ()>,
     do_parse!(
         tag_no_case!("avg_row_length") >>
         opt_multispace >>
@@ -144,15 +145,15 @@ named!(create_option_avg_row_length<()>, complete!(
         integer_literal >>
         ()
     )
-));
+);
 
-named!(create_option_row_format<()>, complete!(
+named!(create_option_row_format<CompleteByteSlice, ()>,
     do_parse!(
         tag_no_case!("row_format") >>
         opt_multispace >>
         opt!(tag!("=")) >>
         opt_multispace >>
-        alt_complete!(
+        alt!(
             tag_no_case!("DEFAULT")|
             tag_no_case!("DYNAMIC") |
             tag_no_case!("FIXED") |
@@ -162,9 +163,9 @@ named!(create_option_row_format<()>, complete!(
         ) >>
         ()
     )
-));
+);
 
-named!(create_option_key_block_size<()>, complete!(
+named!(create_option_key_block_size<CompleteByteSlice, ()>,
     do_parse!(
         tag_no_case!("key_block_size") >>
         opt_multispace >>
@@ -173,17 +174,16 @@ named!(create_option_key_block_size<()>, complete!(
         integer_literal >>
         ()
     )
-));
+);
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use nom::IResult;
 
     fn should_parse_all(qstring: &str) {
         assert_eq!(
-            IResult::Done(&b""[..], ()),
-            table_options(qstring.as_bytes())
+            Ok((CompleteByteSlice(&b""[..]), ())),
+            table_options(CompleteByteSlice(qstring.as_bytes()))
         )
     }
 

--- a/src/delete.rs
+++ b/src/delete.rs
@@ -1,3 +1,4 @@
+use nom::types::CompleteByteSlice;
 use std::{fmt, str};
 
 use common::{opt_multispace, statement_terminator, table_reference};
@@ -24,7 +25,7 @@ impl fmt::Display for DeleteStatement {
     }
 }
 
-named!(pub deletion<&[u8], DeleteStatement>,
+named!(pub deletion<CompleteByteSlice, DeleteStatement>,
     do_parse!(
         tag_no_case!("delete") >>
         delimited!(opt_multispace, tag_no_case!("from"), opt_multispace) >>
@@ -53,7 +54,7 @@ mod tests {
     #[test]
     fn simple_delete() {
         let qstring = "DELETE FROM users;";
-        let res = deletion(qstring.as_bytes());
+        let res = deletion(CompleteByteSlice(qstring.as_bytes()));
         assert_eq!(
             res.unwrap().1,
             DeleteStatement {
@@ -66,7 +67,7 @@ mod tests {
     #[test]
     fn delete_with_where_clause() {
         let qstring = "DELETE FROM users WHERE id = 1;";
-        let res = deletion(qstring.as_bytes());
+        let res = deletion(CompleteByteSlice(qstring.as_bytes()));
         let expected_left = Base(Field(Column::from("id")));
         let expected_where_cond = Some(ComparisonOp(ConditionTree {
             left: Box::new(expected_left),
@@ -87,7 +88,7 @@ mod tests {
     fn format_delete() {
         let qstring = "DELETE FROM users WHERE id = 1";
         let expected = "DELETE FROM users WHERE id = 1";
-        let res = deletion(qstring.as_bytes());
+        let res = deletion(CompleteByteSlice(qstring.as_bytes()));
         assert_eq!(format!("{}", res.unwrap().1), expected);
     }
 }

--- a/src/drop.rs
+++ b/src/drop.rs
@@ -1,3 +1,4 @@
+use nom::types::CompleteByteSlice;
 use std::{fmt, str};
 
 use common::{opt_multispace, statement_terminator, table_list};
@@ -27,7 +28,7 @@ impl fmt::Display for DropTableStatement {
     }
 }
 
-named!(pub drop_table<&[u8], DropTableStatement>,
+named!(pub drop_table<CompleteByteSlice, DropTableStatement>,
     do_parse!(
         tag_no_case!("drop table") >>
         if_exists: opt!(delimited!(opt_multispace, tag_no_case!("if exists"), opt_multispace)) >>
@@ -57,7 +58,7 @@ mod tests {
     #[test]
     fn simple_drop_table() {
         let qstring = "DROP TABLE users;";
-        let res = drop_table(qstring.as_bytes());
+        let res = drop_table(CompleteByteSlice(qstring.as_bytes()));
         assert_eq!(
             res.unwrap().1,
             DropTableStatement {
@@ -71,7 +72,7 @@ mod tests {
     fn format_drop_table() {
         let qstring = "DROP TABLE IF EXISTS users,posts;";
         let expected = "DROP TABLE IF EXISTS users, posts";
-        let res = drop_table(qstring.as_bytes());
+        let res = drop_table(CompleteByteSlice(qstring.as_bytes()));
         assert_eq!(format!("{}", res.unwrap().1), expected);
     }
 }

--- a/src/insert.rs
+++ b/src/insert.rs
@@ -1,4 +1,5 @@
 use nom::multispace;
+use nom::types::CompleteByteSlice;
 use std::fmt;
 use std::str;
 
@@ -53,8 +54,8 @@ impl fmt::Display for InsertStatement {
 
 /// Parse rule for a SQL insert query.
 /// TODO(malte): support REPLACE, nested selection, DEFAULT VALUES
-named!(pub insertion<&[u8], InsertStatement>,
-    complete!(do_parse!(
+named!(pub insertion<CompleteByteSlice, InsertStatement>,
+    do_parse!(
         tag_no_case!("insert") >>
         ignore: opt!(preceded!(multispace, tag_no_case!("ignore"))) >>
         multispace >>
@@ -80,23 +81,23 @@ named!(pub insertion<&[u8], InsertStatement>,
                 values: value_list >>
                 tag!(")") >>
                 opt!(
-                    complete!(do_parse!(
+                    do_parse!(
                             opt_multispace >>
                             tag!(",") >>
                             opt_multispace >>
                             ()
-                    ))
+                    )
                 ) >>
                 (values)
             )
         ) >>
-        upd_if_dup: opt!(complete!(do_parse!(
+        upd_if_dup: opt!(do_parse!(
                 opt_multispace >>
                 tag_no_case!("on duplicate key update") >>
                 multispace >>
                 assigns: assignment_expr_list >>
                 (assigns)
-        ))) >>
+        )) >>
         statement_terminator >>
         ({
             // "table AS alias" isn't legal in INSERT statements
@@ -109,7 +110,7 @@ named!(pub insertion<&[u8], InsertStatement>,
                 on_duplicate: upd_if_dup,
             }
         })
-    ))
+    )
 );
 
 #[cfg(test)]
@@ -123,7 +124,7 @@ mod tests {
     fn simple_insert() {
         let qstring = "INSERT INTO users VALUES (42, \"test\");";
 
-        let res = insertion(qstring.as_bytes());
+        let res = insertion(CompleteByteSlice(qstring.as_bytes()));
         assert_eq!(
             res.unwrap().1,
             InsertStatement {
@@ -139,7 +140,7 @@ mod tests {
     fn complex_insert() {
         let qstring = "INSERT INTO users VALUES (42, 'test', \"test\", CURRENT_TIMESTAMP);";
 
-        let res = insertion(qstring.as_bytes());
+        let res = insertion(CompleteByteSlice(qstring.as_bytes()));
         assert_eq!(
             res.unwrap().1,
             InsertStatement {
@@ -160,7 +161,7 @@ mod tests {
     fn insert_with_field_names() {
         let qstring = "INSERT INTO users (id, name) VALUES (42, \"test\");";
 
-        let res = insertion(qstring.as_bytes());
+        let res = insertion(CompleteByteSlice(qstring.as_bytes()));
         assert_eq!(
             res.unwrap().1,
             InsertStatement {
@@ -177,7 +178,7 @@ mod tests {
     fn insert_without_spaces() {
         let qstring = "INSERT INTO users(id, name) VALUES(42, \"test\");";
 
-        let res = insertion(qstring.as_bytes());
+        let res = insertion(CompleteByteSlice(qstring.as_bytes()));
         assert_eq!(
             res.unwrap().1,
             InsertStatement {
@@ -193,7 +194,7 @@ mod tests {
     fn multi_insert() {
         let qstring = "INSERT INTO users (id, name) VALUES (42, \"test\"),(21, \"test2\");";
 
-        let res = insertion(qstring.as_bytes());
+        let res = insertion(CompleteByteSlice(qstring.as_bytes()));
         assert_eq!(
             res.unwrap().1,
             InsertStatement {
@@ -212,7 +213,7 @@ mod tests {
     fn insert_with_parameters() {
         let qstring = "INSERT INTO users (id, name) VALUES (?, ?);";
 
-        let res = insertion(qstring.as_bytes());
+        let res = insertion(CompleteByteSlice(qstring.as_bytes()));
         assert_eq!(
             res.unwrap().1,
             InsertStatement {
@@ -229,7 +230,7 @@ mod tests {
         let qstring = "INSERT INTO keystores (`key`, `value`) VALUES (?, ?) \
                        ON DUPLICATE KEY UPDATE `value` = `value` + 1";
 
-        let res = insertion(qstring.as_bytes());
+        let res = insertion(CompleteByteSlice(qstring.as_bytes()));
         let expected_ae = ArithmeticExpression {
             op: ArithmeticOperator::Add,
             left: ArithmeticBase::Column(Column::from("value")),

--- a/src/join.rs
+++ b/src/join.rs
@@ -1,3 +1,4 @@
+use nom::types::CompleteByteSlice;
 use std::fmt;
 use std::str;
 
@@ -84,8 +85,8 @@ impl fmt::Display for JoinConstraint {
 }
 
 /// Parse binary comparison operators
-named!(pub join_operator<&[u8], JoinOperator>,
-        alt_complete!(
+named!(pub join_operator<CompleteByteSlice, JoinOperator>,
+        alt!(
               map!(tag_no_case!("join"), |_| JoinOperator::Join)
             | map!(tag_no_case!("left join"), |_| JoinOperator::LeftJoin)
             | map!(tag_no_case!("left outer join"), |_| JoinOperator::LeftOuterJoin)
@@ -109,7 +110,7 @@ mod tests {
         let qstring = "SELECT tags.* FROM tags \
                        INNER JOIN taggings ON tags.id = taggings.tag_id";
 
-        let res = selection(qstring.as_bytes());
+        let res = selection(CompleteByteSlice(qstring.as_bytes()));
 
         let ct = ConditionTree {
             left: Box::new(Base(Field(Column::from("tags.id")))),

--- a/src/keywords.rs
+++ b/src/keywords.rs
@@ -1,11 +1,13 @@
-named!(keyword_follow_char<&[u8], &[u8]>,
-       peek!(alt_complete!(tag!(" ") | tag!("\n") | tag!(";") |
+use nom::types::CompleteByteSlice;
+
+named!(keyword_follow_char<CompleteByteSlice, CompleteByteSlice>,
+       peek!(alt!(tag!(" ") | tag!("\n") | tag!(";") |
                            tag!("(") | tag!(")") | tag!("\t") |
                            tag!(",") | tag!("=") | eof!()))
 );
 
-named!(keyword_a_to_c<&[u8], &[u8]>,
-       alt_complete!(
+named!(keyword_a_to_c<CompleteByteSlice, CompleteByteSlice>,
+       alt!(
           terminated!(tag_no_case!("ABORT"), keyword_follow_char)
         | terminated!(tag_no_case!("ACTION"), keyword_follow_char)
         | terminated!(tag_no_case!("ADD"), keyword_follow_char)
@@ -39,8 +41,8 @@ named!(keyword_a_to_c<&[u8], &[u8]>,
     )
 );
 
-named!(keyword_d_to_i<&[u8], &[u8]>,
-    alt_complete!(
+named!(keyword_d_to_i<CompleteByteSlice, CompleteByteSlice>,
+    alt!(
           terminated!(tag_no_case!("DATABASE"), keyword_follow_char)
         | terminated!(tag_no_case!("DEFAULT"), keyword_follow_char)
         | terminated!(tag_no_case!("DEFERRABLE"), keyword_follow_char)
@@ -83,8 +85,8 @@ named!(keyword_d_to_i<&[u8], &[u8]>,
     )
 );
 
-named!(keyword_j_to_s<&[u8], &[u8]>,
-    alt_complete!(
+named!(keyword_j_to_s<CompleteByteSlice, CompleteByteSlice>,
+    alt!(
           terminated!(tag_no_case!("ORDER"), keyword_follow_char)
         | terminated!(tag_no_case!("JOIN"), keyword_follow_char)
         | terminated!(tag_no_case!("KEY"), keyword_follow_char)
@@ -124,8 +126,8 @@ named!(keyword_j_to_s<&[u8], &[u8]>,
     )
 );
 
-named!(keyword_t_to_z<&[u8], &[u8]>,
-    alt_complete!(
+named!(keyword_t_to_z<CompleteByteSlice, CompleteByteSlice>,
+    alt!(
           terminated!(tag_no_case!("TABLE"), keyword_follow_char)
         | terminated!(tag_no_case!("TEMP"), keyword_follow_char)
         | terminated!(tag_no_case!("TEMPORARY"), keyword_follow_char)
@@ -149,19 +151,19 @@ named!(keyword_t_to_z<&[u8], &[u8]>,
 );
 
 /// Matches any SQL reserved keyword
-named!(pub sql_keyword<&[u8], &[u8]>,
-    complete!(do_parse!(
-        kw: alt_complete!(
+named!(pub sql_keyword<CompleteByteSlice, CompleteByteSlice>,
+    do_parse!(
+        kw: alt!(
               keyword_a_to_c
             | keyword_d_to_i
             | keyword_j_to_s
             | keyword_t_to_z) >>
         (kw)
-    ))
+    )
 );
 
 pub fn escape_if_keyword(s: &str) -> String {
-    if sql_keyword(s.as_bytes()).is_done() {
+    if sql_keyword(CompleteByteSlice(s.as_bytes())).is_ok() {
         format!("`{}`", s)
     } else {
         s.to_owned()

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,4 +1,4 @@
-use nom::IResult;
+use nom::types::CompleteByteSlice;
 use std::fmt;
 use std::str;
 
@@ -40,8 +40,8 @@ impl fmt::Display for SqlQuery {
     }
 }
 
-named!(sql_query<&[u8], SqlQuery>,
-    alt_complete!(
+named!(sql_query<CompleteByteSlice, SqlQuery>,
+    alt!(
           do_parse!(c: creation >> (SqlQuery::CreateTable(c)))
         | do_parse!(i: insertion >> (SqlQuery::Insert(i)))
         | do_parse!(c: compound_selection >> (SqlQuery::CompoundSelect(c)))
@@ -56,10 +56,9 @@ named!(sql_query<&[u8], SqlQuery>,
 
 pub fn parse_query_bytes<T>(input: T) -> Result<SqlQuery, &'static str>
     where T: AsRef<[u8]> {
-    match sql_query(input.as_ref()) {
-        IResult::Done(_, o) => Ok(o),
-        IResult::Error(_) => Err("failed to parse query"),
-        IResult::Incomplete(_) => unreachable!(),
+    match sql_query(CompleteByteSlice(input.as_ref())) {
+        Ok((_, o)) => Ok(o),
+        Err(_) => Err("failed to parse query"),
     }
 }
 

--- a/src/set.rs
+++ b/src/set.rs
@@ -1,4 +1,5 @@
 use nom::multispace;
+use nom::types::CompleteByteSlice;
 use std::{fmt, str};
 
 use common::{literal, opt_multispace, sql_identifier, statement_terminator, Literal};
@@ -17,18 +18,18 @@ impl fmt::Display for SetStatement {
     }
 }
 
-named!(pub set<&[u8], SetStatement>,
+named!(pub set<CompleteByteSlice, SetStatement>,
     do_parse!(
         tag_no_case!("set") >>
         multispace >>
-        var: map_res!(sql_identifier, str::from_utf8) >>
+        var: sql_identifier >>
         opt_multispace >>
         tag_no_case!("=") >>
         opt_multispace >>
         val: literal >>
         statement_terminator >>
         (SetStatement {
-            variable: String::from(var),
+            variable: String::from(str::from_utf8(*var).unwrap()),
             value: val,
         })
     )
@@ -41,7 +42,7 @@ mod tests {
     #[test]
     fn simple_set() {
         let qstring = "SET SQL_AUTO_IS_NULL = 0;";
-        let res = set(qstring.as_bytes());
+        let res = set(CompleteByteSlice(qstring.as_bytes()));
         assert_eq!(
             res.unwrap().1,
             SetStatement {
@@ -55,7 +56,7 @@ mod tests {
     fn format_set() {
         let qstring = "set autocommit=1";
         let expected = "SET autocommit = 1";
-        let res = set(qstring.as_bytes());
+        let res = set(CompleteByteSlice(qstring.as_bytes()));
         assert_eq!(format!("{}", res.unwrap().1), expected);
     }
 }


### PR DESCRIPTION
Hi Malte! 👋 

I was evaluating nom-sql for use in another project and decided it'd be easiest to explore by upgrading it to use nom v4. The diff is annoyingly large but fortunately nearly entirely mechanical. 

---

There were two changes to nom v4 that had a major impact on this crate.

First, nom v4 uses the standard Result type instead of a custom enum.
That means that checking for a successful parse uses the is_ok method
instead of the is_done method.

Second, nom v4 is more aggressive about returning incomplete results.
This caused many tests to fail because the parser required one more
character to determine whether a keyword was finished or not. Work
around the problem by using nom v4's CompleteByteSlice type, which
indicates that the parser is never used with streaming input, and
therefore the end of the input string can be treated as EOF. This has
the added benefit of making all of the complete! macros redundant.