### PR TITLE
Test failures

### DIFF
--- a/tests/hyrise-test-queries.txt
+++ b/tests/hyrise-test-queries.txt
@@ -4,30 +4,30 @@
 # SELECT statement
 SELECT * FROM orders;
 SELECT a FROM foo WHERE a > 12 OR b > 3 AND NOT c LIMIT 10
-SELECT col1 AS myname, col2, 'test' FROM "table", foo AS t WHERE age > 12 AND zipcode = 12345 GROUP BY col1;
-SELECT * from "table" JOIN table2 ON a = b WHERE (b OR NOT a) AND a = 12.5
-(SELECT a FROM foo WHERE a > 12 OR b > 3 AND c NOT LIKE 's%' LIMIT 10);
-SELECT * FROM "table" LIMIT 10 OFFSET 10; SELECT * FROM second;
+-- SELECT col1 AS myname, col2, 'test' FROM "table", foo AS t WHERE age > 12 AND zipcode = 12345 GROUP BY col1;
+-- SELECT * from "table" JOIN table2 ON a = b WHERE (b OR NOT a) AND a = 12.5
+-- (SELECT a FROM foo WHERE a > 12 OR b > 3 AND c NOT LIKE 's%' LIMIT 10);
+-- SELECT * FROM "table" LIMIT 10 OFFSET 10; SELECT * FROM second;
 SELECT * FROM t1 UNION SELECT * FROM t2 ORDER BY col1;
-# SELECT * FROM t1 UNION (SELECT * FROM t2 UNION SELECT * FROM t3) ORDER BY col1; 
+# SELECT * FROM t1 UNION (SELECT * FROM t2 UNION SELECT * FROM t3) ORDER BY col1;
 # JOIN
-SELECT t1.a, t1.b, t2.c FROM "table" AS t1 JOIN (SELECT * FROM foo JOIN bar ON foo.id = bar.id) t2 ON t1.a = t2.b WHERE (t1.b OR NOT t1.a) AND t2.c = 12.5
+-- SELECT t1.a, t1.b, t2.c FROM "table" AS t1 JOIN (SELECT * FROM foo JOIN bar ON foo.id = bar.id) t2 ON t1.a = t2.b WHERE (t1.b OR NOT t1.a) AND t2.c = 12.5
 SELECT * FROM t1 JOIN t2 ON c1 = c2;
 SELECT a, SUM(b) FROM t2 GROUP BY a HAVING SUM(b) > 100;
 # CREATE statement
-CREATE TABLE "table" FROM TBL FILE 'students.tbl'
-CREATE TABLE IF NOT EXISTS "table" FROM TBL FILE 'students.tbl'
+-- CREATE TABLE "table" FROM TBL FILE 'students.tbl'
+-- CREATE TABLE IF NOT EXISTS "table" FROM TBL FILE 'students.tbl'
 CREATE TABLE students (name TEXT, student_number INTEGER, city TEXT, grade DOUBLE)
 # Multiple statements
-CREATE TABLE "table" FROM TBL FILE 'students.tbl'; SELECT * FROM "table";
+-- CREATE TABLE "table" FROM TBL FILE 'students.tbl'; SELECT * FROM "table";
 # INSERT
 INSERT INTO test_table VALUES (1, 2, 'test');
 INSERT INTO test_table (id, value, name) VALUES (1, 2, 'test');
-INSERT INTO test_table SELECT * FROM students;
+-- INSERT INTO test_table SELECT * FROM students;
 # DELETE
 DELETE FROM students WHERE grade > 3.0
 DELETE FROM students
-TRUNCATE students
+-- TRUNCATE students
 # UPDATE
 UPDATE students SET grade = 1.3 WHERE name = 'Max Mustermann';
 UPDATE students SET grade = 1.3, name='Felix Fürstenberg' WHERE name = 'Max Mustermann';
@@ -35,8 +35,8 @@ UPDATE students SET grade = 1.0;
 # DROP
 DROP TABLE students;
 # PREPARE
-PREPARE prep_inst: INSERT INTO test VALUES (?, ?, ?);
-PREPARE prep2 { INSERT INTO test VALUES (?, 0, 0); INSERT INTO test VALUES (0, ?, 0); INSERT INTO test VALUES (0, 0, ?); };
-EXECUTE prep_inst(1, 2, 3);
-EXECUTE prep;
-DEALLOCATE PREPARE prep;
+-- PREPARE prep_inst: INSERT INTO test VALUES (?, ?, ?);
+-- PREPARE prep2 { INSERT INTO test VALUES (?, 0, 0); INSERT INTO test VALUES (0, ?, 0); INSERT INTO test VALUES (0, 0, ?); };
+-- EXECUTE prep_inst(1, 2, 3);
+-- EXECUTE prep;
+-- DEALLOCATE PREPARE prep;

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -8,24 +8,24 @@ fn parse_queryset(queries: Vec<String>) -> (i32, i32) {
     let mut parsed_ok = Vec::new();
     let mut parsed_err = 0;
     for query in queries.iter() {
-        println!("Trying to parse '{}': ", &query);
+        //println!("Trying to parse '{}': ", &query);
         match nom_sql::parser::parse_query(&query) {
             Ok(_) => {
-                println!("ok");
+                //println!("ok");
                 parsed_ok.push(query);
             }
             Err(_) => {
-                println!("failed");
+                println!("failed: '{}'", &query);
                 parsed_err += 1;
             }
         }
     }
 
-    println!("Parsing failed: {} queries", parsed_err);
+    println!("\nParsing failed: {} queries", parsed_err);
     println!("Parsed successfully: {} queries", parsed_ok.len());
-    println!("\nSuccessfully parsed queries:");
+    //println!("\nSuccessfully parsed queries:");
     for q in parsed_ok.iter() {
-        println!("{:?}", q);
+        //println!("{:?}", q);
     }
 
     (parsed_ok.len() as i32, parsed_err)
@@ -39,7 +39,7 @@ fn test_queries_from_file(f: &Path, name: &str) -> Result<i32, i32> {
     f.read_to_string(&mut s).unwrap();
     let lines: Vec<String> = s
         .lines()
-        .filter(|l| !l.is_empty() && !l.starts_with("#"))
+        .filter(|l| !l.is_empty() && !l.starts_with("#") && !l.starts_with("--"))
         .map(|l| {
             if !(l.ends_with("\n") || l.ends_with(";")) {
                 String::from(l) + "\n"
@@ -47,12 +47,15 @@ fn test_queries_from_file(f: &Path, name: &str) -> Result<i32, i32> {
                 String::from(l)
             }
         }).collect();
-    println!("Loaded {} {} queries", lines.len(), name);
+    println!("\nLoaded {} {} queries", lines.len(), name);
 
     // Try parsing them all
-    let (ok, _) = parse_queryset(lines);
+    let (ok, err) = parse_queryset(lines);
 
     // For the moment, we're always good
+    if err > 0 {
+        return Err(err);
+    }
     Ok(ok)
 }
 
@@ -90,7 +93,7 @@ fn parse_file(path: &str) -> (i32, i32) {
     parse_queryset(queries)
 }
 
-#[test]
+#[test] #[ignore]
 fn hotcrp_queries() {
     assert!(test_queries_from_file(Path::new("tests/hotcrp-queries.txt"), "HotCRP").is_ok());
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -8,14 +8,14 @@ fn parse_queryset(queries: Vec<String>) -> (i32, i32) {
     let mut parsed_ok = Vec::new();
     let mut parsed_err = 0;
     for query in queries.iter() {
-        //println!("Trying to parse '{}': ", &query);
+        println!("Trying to parse '{}': ", &query);
         match nom_sql::parser::parse_query(&query) {
             Ok(_) => {
-                //println!("ok");
+                println!("ok");
                 parsed_ok.push(query);
             }
             Err(_) => {
-                println!("failed: '{}'", &query);
+                println!("failed");
                 parsed_err += 1;
             }
         }
@@ -23,9 +23,9 @@ fn parse_queryset(queries: Vec<String>) -> (i32, i32) {
 
     println!("\nParsing failed: {} queries", parsed_err);
     println!("Parsed successfully: {} queries", parsed_ok.len());
-    //println!("\nSuccessfully parsed queries:");
+    println!("\nSuccessfully parsed queries:");
     for q in parsed_ok.iter() {
-        //println!("{:?}", q);
+        println!("{:?}", q);
     }
 
     (parsed_ok.len() as i32, parsed_err)
@@ -39,7 +39,7 @@ fn test_queries_from_file(f: &Path, name: &str) -> Result<i32, i32> {
     f.read_to_string(&mut s).unwrap();
     let lines: Vec<String> = s
         .lines()
-        .filter(|l| !l.is_empty() && !l.starts_with("#") && !l.starts_with("--"))
+        .filter(|l| !l.is_empty() && !l.starts_with("#") && !l.starts_with("--") && !l.starts_with("/*"))
         .map(|l| {
             if !(l.ends_with("\n") || l.ends_with(";")) {
                 String::from(l) + "\n"
@@ -52,7 +52,6 @@ fn test_queries_from_file(f: &Path, name: &str) -> Result<i32, i32> {
     // Try parsing them all
     let (ok, err) = parse_queryset(lines);
 
-    // For the moment, we're always good
     if err > 0 {
         return Err(err);
     }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -39,7 +39,7 @@ fn test_queries_from_file(f: &Path, name: &str) -> Result<i32, i32> {
     f.read_to_string(&mut s).unwrap();
     let lines: Vec<String> = s
         .lines()
-        .filter(|l| !l.is_empty() && !l.starts_with("#") && !l.starts_with("--") && !l.starts_with("/*"))
+        .filter(|l| !l.is_empty() && !l.starts_with("#") && !l.starts_with("--"))
         .map(|l| {
             if !(l.ends_with("\n") || l.ends_with(";")) {
                 String::from(l) + "\n"

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -39,7 +39,12 @@ fn test_queries_from_file(f: &Path, name: &str) -> Result<i32, i32> {
     f.read_to_string(&mut s).unwrap();
     let lines: Vec<String> = s
         .lines()
-        .filter(|l| !l.is_empty() && !l.starts_with("#") && !l.starts_with("--"))
+        .filter(|l| {
+            !l.is_empty()
+                && !l.starts_with("#")
+                && !l.starts_with("--")
+                && !(l.starts_with("/*") && l.ends_with("*/;"))
+        })
         .map(|l| {
             if !(l.ends_with("\n") || l.ends_with(";")) {
                 String::from(l) + "\n"
@@ -72,7 +77,7 @@ fn parse_file(path: &str) -> (i32, i32) {
                 && !l.starts_with("#")
                 && !l.starts_with("--")
                 && !l.starts_with("DROP")
-                && !l.starts_with("/*")
+                && !(l.starts_with("/*") && l.ends_with("*/;"))
         }).collect();
     let mut q = String::new();
     let mut queries = Vec::new();

--- a/tests/tpc-w-queries.txt
+++ b/tests/tpc-w-queries.txt
@@ -11,14 +11,14 @@ SELECT * FROM customer, address, country WHERE customer.c_addr_id = address.addr
 SELECT * FROM item, author WHERE item.i_a_id = author.a_id AND item.i_subject = ? ORDER BY item.i_title limit 50;
 
 # doTitleSearch
-#SELECT * FROM item, author WHERE item.i_a_id = author.a_id AND substring(soundex(item.i_title),0,4)=substring(soundex(?),0,4) ORDER BY item.i_title limit 50;
-SELECT * FROM item, author WHERE item.i_a_id = author.a_id AND substring(soundex(item.i_title),1,4)=substring(soundex(?),1,4) ORDER BY item.i_title limit 50;
-#SELECT * FROM item, author WHERE item.i_a_id = author.a_id AND item.i_title LIKE ? ORDER BY item.i_title limit 50;
+-- SELECT * FROM item, author WHERE item.i_a_id = author.a_id AND substring(soundex(item.i_title),0,4)=substring(soundex(?),0,4) ORDER BY item.i_title limit 50;
+-- SELECT * FROM item, author WHERE item.i_a_id = author.a_id AND substring(soundex(item.i_title),1,4)=substring(soundex(?),1,4) ORDER BY item.i_title limit 50;
+-- SELECT * FROM item, author WHERE item.i_a_id = author.a_id AND item.i_title LIKE ? ORDER BY item.i_title limit 50;
 
 # doAuthorSearch
-#SELECT * FROM author, item WHERE substring(soundex(author.a_lname),0,4)=substring(soundex(?),0,4) AND item.i_a_id = author.a_id ORDER BY item.i_title limit 50;
-SELECT * FROM author, item WHERE substring(soundex(author.a_lname),1,4)=substring(soundex(?),1,4) AND item.i_a_id = author.a_id ORDER BY item.i_title limit 50;
-#SELECT * FROM author, item WHERE author.a_lname LIKE ? AND item.i_a_id = author.a_id ORDER BY item.i_title limit 50;
+-- SELECT * FROM author, item WHERE substring(soundex(author.a_lname),0,4)=substring(soundex(?),0,4) AND item.i_a_id = author.a_id ORDER BY item.i_title limit 50;
+-- SELECT * FROM author, item WHERE substring(soundex(author.a_lname),1,4)=substring(soundex(?),1,4) AND item.i_a_id = author.a_id ORDER BY item.i_title limit 50;
+-- SELECT * FROM author, item WHERE author.a_lname LIKE ? AND item.i_a_id = author.a_id ORDER BY item.i_title limit 50;
 
 # getNewProducts
 SELECT i_id, i_title, a_fname, a_lname FROM item, author WHERE item.i_a_id = author.a_id AND item.i_subject = ? ORDER BY item.i_pub_date DESC,item.i_title limit 50;
@@ -56,7 +56,7 @@ SELECT * FROM order_line, item WHERE ol_o_id = ? AND ol_i_id = i_id;
 # createEmptyCart
 SELECT COUNT(*) FROM shopping_cart;
 # createEmptyCart.insert
-INSERT into shopping_cart (sc_id, sc_time) VALUES ((SELECT COUNT(*) FROM shopping_cart), CURRENT_TIMESTAMP);
+-- INSERT into shopping_cart (sc_id, sc_time) VALUES ((SELECT COUNT(*) FROM shopping_cart), CURRENT_TIMESTAMP);
 # createEmptyCart.insert.v2
 INSERT into shopping_cart (sc_id, sc_time) VALUES (?, CURRENT_TIMESTAMP);
 
@@ -82,7 +82,7 @@ UPDATE shopping_cart SET sc_time = CURRENT_TIMESTAMP WHERE sc_id = ?;
 SELECT * FROM shopping_cart_line, item WHERE scl_i_id = item.i_id AND scl_sc_id = ?;
 
 # refreshSession
-UPDATE customer SET c_login = NOW(), c_expiration = (CURRENT_TIMESTAMP + INTERVAL 2 HOUR) WHERE c_id = ?;
+-- UPDATE customer SET c_login = NOW(), c_expiration = (CURRENT_TIMESTAMP + INTERVAL 2 HOUR) WHERE c_id = ?;
 
 # createNewCustomer
 INSERT into customer (c_id, c_uname, c_passwd, c_fname, c_lname, c_addr_id, c_phone, c_email, c_since, c_last_login, c_login, c_expiration, c_discount, c_balance, c_ytd_pmt, c_birthdate, c_data) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
@@ -99,7 +99,7 @@ SELECT c_addr_id FROM customer WHERE customer.c_id = ?;
 SELECT c_addr_id FROM customer WHERE customer.c_id = ?;
 
 # enterCCXact
-INSERT into cc_xacts (cx_o_id, cx_type, cx_num, cx_name, cx_expire, cx_xact_amt, cx_xact_date, cx_co_id) VALUES (?, ?, ?, ?, ?, ?, CURRENT_DATE, (SELECT co_id FROM address, country WHERE addr_id = ? AND addr_co_id = co_id));
+-- INSERT into cc_xacts (cx_o_id, cx_type, cx_num, cx_name, cx_expire, cx_xact_amt, cx_xact_date, cx_co_id) VALUES (?, ?, ?, ?, ?, ?, CURRENT_DATE, (SELECT co_id FROM address, country WHERE addr_id = ? AND addr_co_id = co_id));
 
 # clearCart
 DELETE FROM shopping_cart_line WHERE scl_sc_id = ?;
@@ -114,7 +114,7 @@ INSERT into address (addr_id, addr_street1, addr_street2, addr_city, addr_state,
 SELECT max(addr_id) FROM address;
 
 # enterOrder.insert
-INSERT into orders (o_id, o_c_id, o_date, o_sub_total, o_tax, o_total, o_ship_type, o_ship_date, o_bill_addr_id, o_ship_addr_id, o_status) VALUES (?, ?, CURRENT_DATE, ?, 8.25, ?, ?, CURRENT_DATE + INTERVAL ? DAY, ?, ?, 'Pending');
+-- INSERT into orders (o_id, o_c_id, o_date, o_sub_total, o_tax, o_total, o_ship_type, o_ship_date, o_bill_addr_id, o_ship_addr_id, o_status) VALUES (?, ?, CURRENT_DATE, ?, 8.25, ?, ?, CURRENT_DATE + INTERVAL ? DAY, ?, ?, 'Pending');
 # enterOrder.maxId
 SELECT count(o_id) FROM orders;
 


### PR DESCRIPTION
Makes changes we discussed last night:
- checks for -- comments
- comments out queries that are failing currently
- fails the test if any uncommented queries fail to parse
- ignores the hotcrp tests since we don't expect them to pass

parse_file also ignores lines that start with DROP, like commented lines, but I wasn't sure why so I haven't included that for now. This also doesn't include the logic that I'm putting in my other crate for making VIEW name: query parse correctly, because it sounds like noria already has that covered.