### PR TITLE
Support MySQL User-Defined Variables

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -302,7 +302,7 @@ impl Display for FieldValueExpression {
 
 #[inline]
 pub fn is_sql_identifier(chr: u8) -> bool {
-    is_alphanumeric(chr) || chr == '_' as u8
+    is_alphanumeric(chr) || chr == '_' as u8 || chr == '@' as u8
 }
 
 #[inline]

--- a/src/set.rs
+++ b/src/set.rs
@@ -53,6 +53,19 @@ mod tests {
     }
 
     #[test]
+    fn user_defined_vars() {
+        let qstring = "SET @var = 123;";
+        let res = set(CompleteByteSlice(qstring.as_bytes()));
+        assert_eq!(
+            res.unwrap().1,
+            SetStatement {
+                variable: "@var".to_owned(),
+                value: 123.into(),
+            }
+        );
+    }
+
+    #[test]
     fn format_set() {
         let qstring = "set autocommit=1";
         let expected = "SET autocommit = 1";


### PR DESCRIPTION
These are prefixed by an `@` sigil:
https://dev.mysql.com/doc/refman/5.7/en/user-variables.html