### PR TITLE
Add placeholder variables

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -101,6 +101,7 @@ pub enum Literal {
     CurrentDate,
     CurrentTimestamp,
     Placeholder,
+    VariablePlaceholder(i32),
 }
 
 impl From<i64> for Literal {
@@ -158,6 +159,7 @@ impl ToString for Literal {
             Literal::CurrentDate => "CURRENT_DATE".to_string(),
             Literal::CurrentTimestamp => "CURRENT_TIMESTAMP".to_string(),
             Literal::Placeholder => "?".to_string(),
+            Literal::VariablePlaceholder(ref i) => format!("${}", i),
         }
     }
 }
@@ -938,6 +940,10 @@ pub fn literal(i: &[u8]) -> IResult<&[u8], Literal> {
         map(tag_no_case("current_date"), |_| Literal::CurrentDate),
         map(tag_no_case("current_time"), |_| Literal::CurrentTime),
         map(tag("?"), |_| Literal::Placeholder),
+        map(preceded(alt((tag(":"), tag("$"))), digit1), |num| {
+            let value = i32::from_str(str::from_utf8(num).unwrap()).unwrap();
+            Literal::VariablePlaceholder(value)
+        }),
     ))(i)
 }
 

--- a/src/condition.rs
+++ b/src/condition.rs
@@ -324,7 +324,7 @@ mod tests {
     use super::*;
     use arithmetic::{ArithmeticBase, ArithmeticOperator};
     use column::Column;
-    use common::{FieldDefinitionExpression, Literal, Operator};
+    use common::{FieldDefinitionExpression, ItemPlaceholder, Literal, Operator};
 
     fn columns(cols: &[&str]) -> Vec<FieldDefinitionExpression> {
         cols.iter()

--- a/src/condition.rs
+++ b/src/condition.rs
@@ -366,37 +366,36 @@ mod tests {
 
     #[test]
     fn equality_placeholder() {
-        let cond = "foo = ?";
-
-        let res = condition_expr(cond.as_bytes());
-        assert_eq!(
-            res.unwrap().1,
-            flat_condition_tree(
-                Operator::Equal,
-                ConditionBase::Field(Column::from("foo")),
-                ConditionBase::Literal(Literal::Placeholder)
-            )
+        x_equality_variable_placeholder(
+            "foo = ?",
+            Literal::Placeholder(ItemPlaceholder::QuestionMark),
         );
     }
 
     #[test]
     fn equality_variable_placeholder() {
-        x_equality_variable_placeholder("foo = :12");
+        x_equality_variable_placeholder(
+            "foo = :12",
+            Literal::Placeholder(ItemPlaceholder::ColonNumber(12)),
+        );
     }
 
     #[test]
     fn equality_variable_placeholder_with_dollar_sign() {
-        x_equality_variable_placeholder("foo = $12");
+        x_equality_variable_placeholder(
+            "foo = $12",
+            Literal::Placeholder(ItemPlaceholder::DollarNumber(12)),
+        );
     }
 
-    fn x_equality_variable_placeholder(cond: &str) {
+    fn x_equality_variable_placeholder(cond: &str, literal: Literal) {
         let res = condition_expr(cond.as_bytes());
         assert_eq!(
             res.unwrap().1,
             flat_condition_tree(
                 Operator::Equal,
                 ConditionBase::Field(Column::from("foo")),
-                ConditionBase::Literal(Literal::VariablePlaceholder(12))
+                ConditionBase::Literal(literal)
             )
         );
     }
@@ -596,7 +595,9 @@ mod tests {
         let a = ComparisonOp(ConditionTree {
             operator: Operator::Equal,
             left: Box::new(Base(Field("foo".into()))),
-            right: Box::new(Base(Literal(Literal::Placeholder))),
+            right: Box::new(Base(Literal(Literal::Placeholder(
+                ItemPlaceholder::QuestionMark,
+            )))),
         });
 
         let b = ComparisonOp(ConditionTree {
@@ -638,7 +639,9 @@ mod tests {
         let a = ComparisonOp(ConditionTree {
             operator: Operator::Equal,
             left: Box::new(Base(Field("foo".into()))),
-            right: Box::new(Base(Literal(Literal::Placeholder))),
+            right: Box::new(Base(Literal(Literal::Placeholder(
+                ItemPlaceholder::QuestionMark,
+            )))),
         });
 
         let b = ComparisonOp(ConditionTree {
@@ -883,7 +886,7 @@ mod tests {
                             right: Box::new(flat_condition_tree(
                                 Operator::Equal,
                                 Field("read_ribbons.user_id".into()),
-                                Literal(Literal::Placeholder),
+                                Literal(Literal::Placeholder(ItemPlaceholder::QuestionMark)),
                             )),
                         })),
                     })),

--- a/src/condition.rs
+++ b/src/condition.rs
@@ -379,6 +379,28 @@ mod tests {
         );
     }
 
+    #[test]
+    fn equality_variable_placeholder() {
+        x_equality_variable_placeholder("foo = :12");
+    }
+
+    #[test]
+    fn equality_variable_placeholder_with_dollar_sign() {
+        x_equality_variable_placeholder("foo = $12");
+    }
+
+    fn x_equality_variable_placeholder(cond: &str) {
+        let res = condition_expr(cond.as_bytes());
+        assert_eq!(
+            res.unwrap().1,
+            flat_condition_tree(
+                Operator::Equal,
+                ConditionBase::Field(Column::from("foo")),
+                ConditionBase::Literal(Literal::VariablePlaceholder(12))
+            )
+        );
+    }
+
     fn x_operator_value(op: ArithmeticOperator, value: Literal) -> ConditionExpression {
         ConditionExpression::Arithmetic(Box::new(ArithmeticExpression::new(
             op,

--- a/src/insert.rs
+++ b/src/insert.rs
@@ -118,6 +118,7 @@ mod tests {
     use super::*;
     use arithmetic::{ArithmeticBase, ArithmeticExpression, ArithmeticOperator};
     use column::Column;
+    use common::ItemPlaceholder;
     use table::Table;
 
     #[test]
@@ -219,7 +220,10 @@ mod tests {
             InsertStatement {
                 table: Table::from("users"),
                 fields: Some(vec![Column::from("id"), Column::from("name")]),
-                data: vec![vec![Literal::Placeholder, Literal::Placeholder]],
+                data: vec![vec![
+                    Literal::Placeholder(ItemPlaceholder::QuestionMark),
+                    Literal::Placeholder(ItemPlaceholder::QuestionMark)
+                ]],
                 ..Default::default()
             }
         );
@@ -227,7 +231,7 @@ mod tests {
 
     #[test]
     fn insert_with_on_dup_update() {
-        let qstring = "INSERT INTO keystores (`key`, `value`) VALUES (?, ?) \
+        let qstring = "INSERT INTO keystores (`key`, `value`) VALUES ($1, :2) \
                        ON DUPLICATE KEY UPDATE `value` = `value` + 1";
 
         let res = insertion(qstring.as_bytes());
@@ -242,7 +246,10 @@ mod tests {
             InsertStatement {
                 table: Table::from("keystores"),
                 fields: Some(vec![Column::from("key"), Column::from("value")]),
-                data: vec![vec![Literal::Placeholder, Literal::Placeholder]],
+                data: vec![vec![
+                    Literal::Placeholder(ItemPlaceholder::DollarNumber(1)),
+                    Literal::Placeholder(ItemPlaceholder::ColonNumber(2))
+                ]],
                 on_duplicate: Some(vec![(
                     Column::from("value"),
                     FieldValueExpression::Arithmetic(expected_ae),

--- a/src/select.rs
+++ b/src/select.rs
@@ -479,6 +479,29 @@ mod tests {
     }
 
     #[test]
+    fn where_clause_with_variable_placeholder() {
+        let qstring = "select * from ContactInfo where email=$1;";
+
+        let res = selection(qstring.as_bytes());
+
+        let expected_left = Base(Field(Column::from("email")));
+        let expected_where_cond = Some(ComparisonOp(ConditionTree {
+            left: Box::new(expected_left),
+            right: Box::new(Base(Literal(Literal::VariablePlaceholder(1)))),
+            operator: Operator::Equal,
+        }));
+        assert_eq!(
+            res.unwrap().1,
+            SelectStatement {
+                tables: vec![Table::from("ContactInfo")],
+                fields: vec![FieldDefinitionExpression::All],
+                where_clause: expected_where_cond,
+                ..Default::default()
+            }
+        );
+    }
+
+    #[test]
     fn limit_clause() {
         let qstring1 = "select * from users limit 10\n";
         let qstring2 = "select * from users limit 10 offset 10\n";

--- a/src/select.rs
+++ b/src/select.rs
@@ -311,7 +311,9 @@ mod tests {
     use super::*;
     use case::{CaseWhenExpression, ColumnOrLiteral};
     use column::{Column, FunctionArguments, FunctionExpression};
-    use common::{FieldDefinitionExpression, FieldValueExpression, Literal, Operator};
+    use common::{
+        FieldDefinitionExpression, FieldValueExpression, ItemPlaceholder, Literal, Operator,
+    };
     use condition::ConditionBase::*;
     use condition::ConditionExpression::*;
     use condition::ConditionTree;
@@ -457,37 +459,35 @@ mod tests {
 
     #[test]
     fn where_clause() {
-        let qstring = "select * from ContactInfo where email=?;";
-
-        let res = selection(qstring.as_bytes());
-
-        let expected_left = Base(Field(Column::from("email")));
-        let expected_where_cond = Some(ComparisonOp(ConditionTree {
-            left: Box::new(expected_left),
-            right: Box::new(Base(Literal(Literal::Placeholder))),
-            operator: Operator::Equal,
-        }));
-        assert_eq!(
-            res.unwrap().1,
-            SelectStatement {
-                tables: vec![Table::from("ContactInfo")],
-                fields: vec![FieldDefinitionExpression::All],
-                where_clause: expected_where_cond,
-                ..Default::default()
-            }
+        where_clause_with_variable_placeholder(
+            "select * from ContactInfo where email=?;",
+            Literal::Placeholder(ItemPlaceholder::QuestionMark),
         );
     }
 
     #[test]
-    fn where_clause_with_variable_placeholder() {
-        let qstring = "select * from ContactInfo where email=$1;";
+    fn where_clause_with_dollar_variable() {
+        where_clause_with_variable_placeholder(
+            "select * from ContactInfo where email= $3;",
+            Literal::Placeholder(ItemPlaceholder::DollarNumber(3)),
+        );
+    }
 
+    #[test]
+    fn where_clause_with_colon_variable() {
+        where_clause_with_variable_placeholder(
+            "select * from ContactInfo where email= :5;",
+            Literal::Placeholder(ItemPlaceholder::ColonNumber(5)),
+        );
+    }
+
+    fn where_clause_with_variable_placeholder(qstring: &str, literal: Literal) {
         let res = selection(qstring.as_bytes());
 
         let expected_left = Base(Field(Column::from("email")));
         let expected_where_cond = Some(ComparisonOp(ConditionTree {
             left: Box::new(expected_left),
-            right: Box::new(Base(Literal(Literal::VariablePlaceholder(1)))),
+            right: Box::new(Base(Literal(literal))),
             operator: Operator::Equal,
         }));
         assert_eq!(
@@ -620,7 +620,9 @@ mod tests {
         let expected_left = Base(Field(Column::from("paperId")));
         let expected_where_cond = Some(ComparisonOp(ConditionTree {
             left: Box::new(expected_left),
-            right: Box::new(Base(Literal(Literal::Placeholder))),
+            right: Box::new(Base(Literal(Literal::Placeholder(
+                ItemPlaceholder::QuestionMark,
+            )))),
             operator: Operator::Equal,
         }));
         assert_eq!(
@@ -643,13 +645,17 @@ mod tests {
 
         let left_ct = ConditionTree {
             left: Box::new(Base(Field(Column::from("paperId")))),
-            right: Box::new(Base(Literal(Literal::Placeholder))),
+            right: Box::new(Base(Literal(Literal::Placeholder(
+                ItemPlaceholder::QuestionMark,
+            )))),
             operator: Operator::Equal,
         };
         let left_comp = Box::new(ComparisonOp(left_ct));
         let right_ct = ConditionTree {
             left: Box::new(Base(Field(Column::from("paperStorageId")))),
-            right: Box::new(Base(Literal(Literal::Placeholder))),
+            right: Box::new(Base(Literal(Literal::Placeholder(
+                ItemPlaceholder::QuestionMark,
+            )))),
             operator: Operator::Equal,
         };
         let right_comp = Box::new(ComparisonOp(right_ct));
@@ -680,7 +686,9 @@ mod tests {
         });
         let ct = ConditionTree {
             left: Box::new(Base(Field(Column::from("id")))),
-            right: Box::new(Base(Literal(Literal::Placeholder))),
+            right: Box::new(Base(Literal(Literal::Placeholder(
+                ItemPlaceholder::QuestionMark,
+            )))),
             operator: Operator::Equal,
         };
         let expected_where_cond = Some(ComparisonOp(ct));
@@ -954,7 +962,9 @@ mod tests {
             })),
             right: Box::new(ComparisonOp(ConditionTree {
                 left: Box::new(Base(Field(Column::from("item.i_subject")))),
-                right: Box::new(Base(Literal(Literal::Placeholder))),
+                right: Box::new(Base(Literal(Literal::Placeholder(
+                    ItemPlaceholder::QuestionMark,
+                )))),
                 operator: Operator::Equal,
             })),
             operator: Operator::And,
@@ -1053,7 +1063,9 @@ mod tests {
         let res = selection(qstring.as_bytes());
         let ct = ConditionTree {
             left: Box::new(Base(Field(Column::from("ContactInfo.contactId")))),
-            right: Box::new(Base(Literal(Literal::Placeholder))),
+            right: Box::new(Base(Literal(Literal::Placeholder(
+                ItemPlaceholder::QuestionMark,
+            )))),
             operator: Operator::Equal,
         };
         let expected_where_cond = Some(ComparisonOp(ct));

--- a/src/update.rs
+++ b/src/update.rs
@@ -68,7 +68,7 @@ mod tests {
     use super::*;
     use arithmetic::{ArithmeticBase, ArithmeticExpression, ArithmeticOperator};
     use column::Column;
-    use common::{Literal, LiteralExpression, Operator, Real};
+    use common::{ItemPlaceholder, Literal, LiteralExpression, Operator, Real};
     use condition::ConditionBase::*;
     use condition::ConditionExpression::*;
     use condition::ConditionTree;
@@ -149,7 +149,9 @@ mod tests {
         let expected_left = Base(Field(Column::from("stories.id")));
         let expected_where_cond = Some(ComparisonOp(ConditionTree {
             left: Box::new(expected_left),
-            right: Box::new(Base(Literal(Literal::Placeholder))),
+            right: Box::new(Base(Literal(Literal::Placeholder(
+                ItemPlaceholder::QuestionMark,
+            )))),
             operator: Operator::Equal,
         }));
         assert_eq!(
@@ -178,7 +180,9 @@ mod tests {
         let res = updating(qstring.as_bytes());
         let expected_where_cond = Some(ComparisonOp(ConditionTree {
             left: Box::new(Base(Field(Column::from("users.id")))),
-            right: Box::new(Base(Literal(Literal::Placeholder))),
+            right: Box::new(Base(Literal(Literal::Placeholder(
+                ItemPlaceholder::QuestionMark,
+            )))),
             operator: Operator::Equal,
         }));
         let expected_ae = ArithmeticExpression {


### PR DESCRIPTION
Enable parsing queries, which contains :1 or $1 style variables

Fixes #42 