### PR TITLE
Select expressions must have at least one table

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -890,7 +890,7 @@ pub fn field_definition_expr(i: &[u8]) -> IResult<&[u8], Vec<FieldDefinitionExpr
 // Parse list of table names.
 // XXX(malte): add support for aliases
 pub fn table_list(i: &[u8]) -> IResult<&[u8], Vec<Table>> {
-    many0(terminated(schema_table_reference, opt(ws_sep_comma)))(i)
+    many1(terminated(schema_table_reference, opt(ws_sep_comma)))(i)
 }
 
 // Integer literal value

--- a/src/select.rs
+++ b/src/select.rs
@@ -342,6 +342,13 @@ mod tests {
     }
 
     #[test]
+    fn select_without_table() {
+        let qstring = "SELECT * FROM;";
+        let res = selection(qstring.as_bytes());
+        assert!(res.is_err(), "!{:?}.is_err()", res);
+    }
+
+    #[test]
     fn more_involved_select() {
         let qstring = "SELECT users.id, users.name FROM users;";
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -213,6 +213,6 @@ fn parse_autoincrement() {
 #[test]
 fn parse_select() {
     let (ok, fail) = parse_file("tests/select.txt");
-    assert_eq!(fail, 0);
+    assert_eq!(fail, 1);
     assert_eq!(ok, 27);
 }

--- a/tests/select.txt
+++ b/tests/select.txt
@@ -1,3 +1,4 @@
+select * from;
 
 select a + b from c;
 select a + 2 from c;


### PR DESCRIPTION
Without this, `select * from;` parses successfully, even though it
shouldn't.