### PR TITLE
ensure IS/IS NOT NULL parses correctly

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -219,6 +219,7 @@ pub enum Operator {
     In,
     NotIn,
     Is,
+    IsNot
 }
 
 impl Display for Operator {
@@ -237,6 +238,7 @@ impl Display for Operator {
             Operator::LessOrEqual => "<=",
             Operator::In => "IN",
             Operator::NotIn => "NOT IN",
+            Operator::IsNot => "IS NOT",
             Operator::Is => "IS",
         };
         write!(f, "{}", op)

--- a/src/select.rs
+++ b/src/select.rs
@@ -936,7 +936,7 @@ mod tests {
             left: Box::new(ComparisonOp(ConditionTree {
                 left: Box::new(Base(Field(Column::from("votes.story_id")))),
                 right: Box::new(Base(Literal(Literal::Null))),
-                operator: Operator::Equal,
+                operator: Operator::Is,
             })),
             right: Box::new(ComparisonOp(ConditionTree {
                 left: Box::new(Base(Field(Column::from("votes.vote")))),


### PR DESCRIPTION
This is an attempt at fixing https://github.com/ms705/nom-sql/issues/22 and followed the suggestion mentioned in https://github.com/ms705/nom-sql/issues/22#issuecomment-421404638 for the solution. I added Operator::IsNot in order to handle the negative condition as well.

I included a test for `= NULL` and `!= NULL`. 

Hopefully this fits with the solution you were looking for. If not, please let me know how you would like for me to improve upon it.