### PR TITLE
Optional object clauses allowing literal selects

### DIFF
--- a/src/arithmetic.rs
+++ b/src/arithmetic.rs
@@ -459,10 +459,13 @@ mod tests {
     }
 
     #[test]
-    fn arithmetic_scalar(){
+    fn arithmetic_scalar() {
         let qs = "56";
         let res = arithmetic(qs.as_bytes());
         assert!(res.is_err());
-        assert_eq!(nom::Err::Error(nom::error::Error::new(qs.as_bytes(), ErrorKind::Tag)), res.err().unwrap());
+        assert_eq!(
+            nom::Err::Error(nom::error::Error::new(qs.as_bytes(), ErrorKind::Tag)),
+            res.err().unwrap()
+        );
     }
 }

--- a/src/compound_select.rs
+++ b/src/compound_select.rs
@@ -185,12 +185,18 @@ mod tests {
         assert!(&res.is_err());
         assert_eq!(
             res.unwrap_err(),
-            nom::Err::Error(nom::error::Error::new(");".as_bytes(), nom::error::ErrorKind::Tag))
+            nom::Err::Error(nom::error::Error::new(
+                ");".as_bytes(),
+                nom::error::ErrorKind::Tag
+            ))
         );
         assert!(&res2.is_err());
         assert_eq!(
             res2.unwrap_err(),
-            nom::Err::Error(nom::error::Error::new(";".as_bytes(), nom::error::ErrorKind::Tag))
+            nom::Err::Error(nom::error::Error::new(
+                ";".as_bytes(),
+                nom::error::ErrorKind::Tag
+            ))
         );
         assert!(&res3.is_err());
         assert_eq!(

--- a/src/condition.rs
+++ b/src/condition.rs
@@ -291,10 +291,7 @@ fn predicate(i: &[u8]) -> IResult<&[u8], ConditionExpression> {
         },
     );
 
-    alt((
-        simple_expr,
-        nested_exists,
-    ))(i)
+    alt((simple_expr, nested_exists))(i)
 }
 
 fn simple_expr(i: &[u8]) -> IResult<&[u8], ConditionExpression> {

--- a/src/create.rs
+++ b/src/create.rs
@@ -5,8 +5,8 @@ use std::str::FromStr;
 
 use column::{Column, ColumnConstraint, ColumnSpecification};
 use common::{
-    column_identifier_no_alias, parse_comment, sql_identifier, statement_terminator,
-    schema_table_reference, type_identifier, ws_sep_comma, Literal, Real, SqlType, TableKey,
+    column_identifier_no_alias, parse_comment, schema_table_reference, sql_identifier,
+    statement_terminator, type_identifier, ws_sep_comma, Literal, Real, SqlType, TableKey,
 };
 use compound_select::{compound_selection, CompoundSelectStatement};
 use create_table_options::table_options;
@@ -534,7 +534,7 @@ mod tests {
         assert_eq!(
             res.unwrap().1,
             CreateTableStatement {
-                table: Table::from(("db1","t")),
+                table: Table::from(("db1", "t")),
                 fields: vec![ColumnSpecification::new(
                     Column::from("t.x"),
                     SqlType::Int(32)

--- a/src/delete.rs
+++ b/src/delete.rs
@@ -1,7 +1,7 @@
 use nom::character::complete::multispace1;
 use std::{fmt, str};
 
-use common::{statement_terminator, schema_table_reference};
+use common::{schema_table_reference, statement_terminator};
 use condition::ConditionExpression;
 use keywords::escape_if_keyword;
 use nom::bytes::complete::tag_no_case;
@@ -77,7 +77,7 @@ mod tests {
         assert_eq!(
             res.unwrap().1,
             DeleteStatement {
-                table: Table::from(("db1","users")),
+                table: Table::from(("db1", "users")),
                 ..Default::default()
             }
         );

--- a/src/insert.rs
+++ b/src/insert.rs
@@ -4,7 +4,7 @@ use std::str;
 
 use column::Column;
 use common::{
-    assignment_expr_list, field_list, statement_terminator, schema_table_reference, value_list,
+    assignment_expr_list, field_list, schema_table_reference, statement_terminator, value_list,
     ws_sep_comma, FieldValueExpression, Literal,
 };
 use keywords::escape_if_keyword;
@@ -145,7 +145,7 @@ mod tests {
         assert_eq!(
             res.unwrap().1,
             InsertStatement {
-                table: Table::from(("db1","users")),
+                table: Table::from(("db1", "users")),
                 fields: None,
                 data: vec![vec![42.into(), "test".into()]],
                 ..Default::default()

--- a/src/join.rs
+++ b/src/join.rs
@@ -128,12 +128,12 @@ mod tests {
         let join_cond = ConditionExpression::ComparisonOp(ct);
         let expected_stmt = SelectStatement {
             tables: vec![Table::from("tags")],
-            fields: vec![FieldDefinitionExpression::AllInTable("tags".into())],
             join: vec![JoinClause {
                 operator: JoinOperator::InnerJoin,
                 right: JoinRightSide::Table(Table::from("taggings")),
                 constraint: JoinConstraint::On(join_cond),
             }],
+            fields: vec![FieldDefinitionExpression::AllInTable("tags".into())],
             ..Default::default()
         };
 


### PR DESCRIPTION
This adds the ability to parse sql literals for https://github.com/ms705/nom-sql/issues/56. This change makes the FROM and table lists optional while ensuring that a join without a from or before a from is invalid. 