### PR TITLE
support for complex sorting clauses

### DIFF
--- a/src/arithmetic.rs
+++ b/src/arithmetic.rs
@@ -459,10 +459,13 @@ mod tests {
     }
 
     #[test]
-    fn arithmetic_scalar(){
+    fn arithmetic_scalar() {
         let qs = "56";
         let res = arithmetic(qs.as_bytes());
         assert!(res.is_err());
-        assert_eq!(nom::Err::Error(nom::error::Error::new(qs.as_bytes(), ErrorKind::Tag)), res.err().unwrap());
+        assert_eq!(
+            nom::Err::Error(nom::error::Error::new(qs.as_bytes(), ErrorKind::Tag)),
+            res.err().unwrap()
+        );
     }
 }

--- a/src/column.rs
+++ b/src/column.rs
@@ -160,6 +160,21 @@ impl PartialOrd for Column {
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub enum SortingColumnIdentifier {
+    FunctionArguments(FunctionArgument),
+    Position(usize),
+}
+
+impl fmt::Display for SortingColumnIdentifier {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            SortingColumnIdentifier::FunctionArguments(c) => write!(f, "{}", c),
+            SortingColumnIdentifier::Position(p) => write!(f, "{}", p),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub enum ColumnConstraint {
     NotNull,
     CharacterSet(String),

--- a/src/compound_select.rs
+++ b/src/compound_select.rs
@@ -185,12 +185,18 @@ mod tests {
         assert!(&res.is_err());
         assert_eq!(
             res.unwrap_err(),
-            nom::Err::Error(nom::error::Error::new(");".as_bytes(), nom::error::ErrorKind::Tag))
+            nom::Err::Error(nom::error::Error::new(
+                ");".as_bytes(),
+                nom::error::ErrorKind::Tag
+            ))
         );
         assert!(&res2.is_err());
         assert_eq!(
             res2.unwrap_err(),
-            nom::Err::Error(nom::error::Error::new(";".as_bytes(), nom::error::ErrorKind::Tag))
+            nom::Err::Error(nom::error::Error::new(
+                ";".as_bytes(),
+                nom::error::ErrorKind::Tag
+            ))
         );
         assert!(&res3.is_err());
         assert_eq!(

--- a/src/condition.rs
+++ b/src/condition.rs
@@ -291,10 +291,7 @@ fn predicate(i: &[u8]) -> IResult<&[u8], ConditionExpression> {
         },
     );
 
-    alt((
-        simple_expr,
-        nested_exists,
-    ))(i)
+    alt((simple_expr, nested_exists))(i)
 }
 
 fn simple_expr(i: &[u8]) -> IResult<&[u8], ConditionExpression> {

--- a/src/create.rs
+++ b/src/create.rs
@@ -5,8 +5,8 @@ use std::str::FromStr;
 
 use column::{Column, ColumnConstraint, ColumnSpecification};
 use common::{
-    column_identifier_no_alias, parse_comment, sql_identifier, statement_terminator,
-    schema_table_reference, type_identifier, ws_sep_comma, Literal, Real, SqlType, TableKey,
+    column_identifier_no_alias, parse_comment, schema_table_reference, sql_identifier,
+    statement_terminator, type_identifier, ws_sep_comma, Literal, Real, SqlType, TableKey,
 };
 use compound_select::{compound_selection, CompoundSelectStatement};
 use create_table_options::table_options;
@@ -534,7 +534,7 @@ mod tests {
         assert_eq!(
             res.unwrap().1,
             CreateTableStatement {
-                table: Table::from(("db1","t")),
+                table: Table::from(("db1", "t")),
                 fields: vec![ColumnSpecification::new(
                     Column::from("t.x"),
                     SqlType::Int(32)

--- a/src/delete.rs
+++ b/src/delete.rs
@@ -1,7 +1,7 @@
 use nom::character::complete::multispace1;
 use std::{fmt, str};
 
-use common::{statement_terminator, schema_table_reference};
+use common::{schema_table_reference, statement_terminator};
 use condition::ConditionExpression;
 use keywords::escape_if_keyword;
 use nom::bytes::complete::tag_no_case;
@@ -77,7 +77,7 @@ mod tests {
         assert_eq!(
             res.unwrap().1,
             DeleteStatement {
-                table: Table::from(("db1","users")),
+                table: Table::from(("db1", "users")),
                 ..Default::default()
             }
         );

--- a/src/insert.rs
+++ b/src/insert.rs
@@ -4,7 +4,7 @@ use std::str;
 
 use column::Column;
 use common::{
-    assignment_expr_list, field_list, statement_terminator, schema_table_reference, value_list,
+    assignment_expr_list, field_list, schema_table_reference, statement_terminator, value_list,
     ws_sep_comma, FieldValueExpression, Literal,
 };
 use keywords::escape_if_keyword;
@@ -145,7 +145,7 @@ mod tests {
         assert_eq!(
             res.unwrap().1,
             InsertStatement {
-                table: Table::from(("db1","users")),
+                table: Table::from(("db1", "users")),
                 fields: None,
                 data: vec![vec![42.into(), "test".into()]],
                 ..Default::default()

--- a/src/order.rs
+++ b/src/order.rs
@@ -2,15 +2,17 @@ use nom::character::complete::{multispace0, multispace1};
 use std::fmt;
 use std::str;
 
-use column::Column;
-use common::{column_identifier_no_alias, ws_sep_comma};
+use column::SortingColumnIdentifier;
+use common::{sorting_column_identifier, ws_sep_comma};
+use condition::condition_expr;
 use keywords::escape_if_keyword;
 use nom::branch::alt;
 use nom::bytes::complete::tag_no_case;
 use nom::combinator::{map, opt};
-use nom::multi::many0;
+use nom::multi::many1;
 use nom::sequence::{preceded, tuple};
 use nom::IResult;
+use ConditionExpression;
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub enum OrderType {
@@ -28,22 +30,37 @@ impl fmt::Display for OrderType {
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub enum OrderingExpression {
+    Columns(Vec<(SortingColumnIdentifier, OrderType)>),
+    Condition(ConditionExpression),
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct OrderClause {
-    pub columns: Vec<(Column, OrderType)>, // TODO(malte): can this be an arbitrary expr?
+    pub expression: OrderingExpression,
 }
 
 impl fmt::Display for OrderClause {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "ORDER BY ")?;
-        write!(
-            f,
-            "{}",
-            self.columns
-                .iter()
-                .map(|&(ref c, ref o)| format!("{} {}", escape_if_keyword(&c.name), o))
-                .collect::<Vec<_>>()
-                .join(", ")
-        )
+
+        match &self.expression {
+            OrderingExpression::Columns(c) => {
+                write!(
+                    f,
+                    "{}",
+                    c.iter()
+                        .map(|&(ref c, ref o)| {
+                            format!("{} {}", escape_if_keyword(&c.to_string()), o)
+                        })
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                )
+            }
+            OrderingExpression::Condition(c) => {
+                write!(f, "{}", c)
+            }
+        }
     }
 }
 
@@ -54,9 +71,19 @@ pub fn order_type(i: &[u8]) -> IResult<&[u8], OrderType> {
     ))(i)
 }
 
-fn order_expr(i: &[u8]) -> IResult<&[u8], (Column, OrderType)> {
+fn order_expr(i: &[u8]) -> IResult<&[u8], OrderingExpression> {
+    alt((
+        map(many1(order_sorting_column), |c| {
+            OrderingExpression::Columns(c)
+        }),
+        map(condition_expr, |c| OrderingExpression::Condition(c)),
+    ))(i)
+}
+
+fn order_sorting_column(i: &[u8]) -> IResult<&[u8], (SortingColumnIdentifier, OrderType)> {
     let (remaining_input, (field_name, ordering, _)) = tuple((
-        column_identifier_no_alias,
+        //column_identifier_no_alias,
+        sorting_column_identifier,
         opt(preceded(multispace0, order_type)),
         opt(ws_sep_comma),
     ))(i)?;
@@ -69,38 +96,61 @@ fn order_expr(i: &[u8]) -> IResult<&[u8], (Column, OrderType)> {
 
 // Parse ORDER BY clause
 pub fn order_clause(i: &[u8]) -> IResult<&[u8], OrderClause> {
-    let (remaining_input, (_, _, _, columns)) = tuple((
+    let (remaining_input, (_, _, _, oe)) = tuple((
         multispace0,
         tag_no_case("order by"),
         multispace1,
-        many0(order_expr),
+        order_expr,
     ))(i)?;
 
-    Ok((remaining_input, OrderClause { columns }))
+    Ok((remaining_input, OrderClause { expression: oe }))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use common::Literal;
+    use condition::ConditionBase::*;
+    use condition::ConditionTree;
     use select::selection;
+    use Column;
+    use ConditionExpression::{Base, ComparisonOp};
+    use {CaseWhenExpression, Operator};
+    use {ColumnOrLiteral, FunctionArgument};
 
     #[test]
-    fn order_clause() {
+    fn order_by_clause() {
         let qstring1 = "select * from users order by name desc\n";
         let qstring2 = "select * from users order by name asc, age desc\n";
         let qstring3 = "select * from users order by name\n";
 
         let expected_ord1 = OrderClause {
-            columns: vec![("name".into(), OrderType::OrderDescending)],
+            expression: OrderingExpression::Columns(vec![(
+                SortingColumnIdentifier::FunctionArguments(FunctionArgument::Column("name".into())),
+                OrderType::OrderDescending,
+            )]),
         };
         let expected_ord2 = OrderClause {
-            columns: vec![
-                ("name".into(), OrderType::OrderAscending),
-                ("age".into(), OrderType::OrderDescending),
-            ],
+            expression: OrderingExpression::Columns(vec![
+                (
+                    SortingColumnIdentifier::FunctionArguments(FunctionArgument::Column(
+                        "name".into(),
+                    )),
+                    OrderType::OrderAscending,
+                ),
+                (
+                    SortingColumnIdentifier::FunctionArguments(FunctionArgument::Column(
+                        "age".into(),
+                    )),
+                    OrderType::OrderDescending,
+                ),
+            ]),
         };
         let expected_ord3 = OrderClause {
-            columns: vec![("name".into(), OrderType::OrderAscending)],
+            expression: OrderingExpression::Columns(vec![(
+                SortingColumnIdentifier::FunctionArguments(FunctionArgument::Column("name".into())),
+                OrderType::OrderAscending,
+            )]),
         };
 
         let res1 = selection(qstring1.as_bytes());
@@ -109,5 +159,67 @@ mod tests {
         assert_eq!(res1.unwrap().1.order, Some(expected_ord1));
         assert_eq!(res2.unwrap().1.order, Some(expected_ord2));
         assert_eq!(res3.unwrap().1.order, Some(expected_ord3));
+    }
+
+    #[test]
+    fn order_by_case() {
+        let qstring = "ORDER BY CASE WHEN vote_id > 10 THEN vote_id END DESC";
+
+        let res = order_clause(qstring.as_bytes());
+
+        let filter_cond = ComparisonOp(ConditionTree {
+            left: Box::new(Base(Field(Column::from("vote_id")))),
+            right: Box::new(Base(Literal(Literal::Integer(10.into())))),
+            operator: Operator::Greater,
+        });
+        let expected = OrderClause {
+            expression: OrderingExpression::Columns(vec![(
+                SortingColumnIdentifier::FunctionArguments(FunctionArgument::Conditional(
+                    CaseWhenExpression {
+                        then_expr: ColumnOrLiteral::Column(Column::from("vote_id")),
+                        else_expr: None,
+                        condition: filter_cond,
+                    },
+                )),
+                OrderType::OrderDescending,
+            )]),
+        };
+
+        assert_eq!(res.unwrap().1, expected);
+    }
+
+    #[test]
+    fn order_by_positionals() {
+        let qstring0 = "ORDER BY 1";
+        let qstring1 = "ORDER BY 1, 5, 3";
+
+        let res0 = order_clause(qstring0.as_bytes());
+        let res1 = order_clause(qstring1.as_bytes());
+
+        let expected0 = OrderClause {
+            expression: OrderingExpression::Columns(vec![(
+                SortingColumnIdentifier::Position(1),
+                OrderType::OrderAscending,
+            )]),
+        };
+        let expected1 = OrderClause {
+            expression: OrderingExpression::Columns(vec![
+                (
+                    SortingColumnIdentifier::Position(1),
+                    OrderType::OrderAscending,
+                ),
+                (
+                    SortingColumnIdentifier::Position(5),
+                    OrderType::OrderAscending,
+                ),
+                (
+                    SortingColumnIdentifier::Position(3),
+                    OrderType::OrderAscending,
+                ),
+            ]),
+        };
+
+        assert_eq!(res0.unwrap().1, expected0);
+        assert_eq!(res1.unwrap().1, expected1);
     }
 }


### PR DESCRIPTION
Added the additional features supported by ORDER BY and GROUP by as mentioned in https://github.com/ms705/nom-sql/issues/73. Positional values are treated separately from a `Column`, since it can only exist in those two places (and has been deprecated in those places).