### PR TITLE
Insert parsing improvements

### DIFF
--- a/src/arithmetic.rs
+++ b/src/arithmetic.rs
@@ -459,10 +459,13 @@ mod tests {
     }
 
     #[test]
-    fn arithmetic_scalar(){
+    fn arithmetic_scalar() {
         let qs = "56";
         let res = arithmetic(qs.as_bytes());
         assert!(res.is_err());
-        assert_eq!(nom::Err::Error(nom::error::Error::new(qs.as_bytes(), ErrorKind::Tag)), res.err().unwrap());
+        assert_eq!(
+            nom::Err::Error(nom::error::Error::new(qs.as_bytes(), ErrorKind::Tag)),
+            res.err().unwrap()
+        );
     }
 }

--- a/src/common.rs
+++ b/src/common.rs
@@ -388,7 +388,7 @@ where
                 let (inp, _) = first.parse(inp)?;
                 let (inp, o2) = second.parse(inp)?;
                 third.parse(inp).map(|(i, _)| (i, o2))
-            },
+            }
         }
     }
 }
@@ -641,7 +641,8 @@ pub fn function_argument_parser(i: &[u8]) -> IResult<&[u8], FunctionArgument> {
 // present.
 pub fn function_arguments(i: &[u8]) -> IResult<&[u8], (FunctionArgument, bool)> {
     let distinct_parser = opt(tuple((tag_no_case("distinct"), multispace1)));
-    let (remaining_input, (distinct, args)) = tuple((distinct_parser, function_argument_parser))(i)?;
+    let (remaining_input, (distinct, args)) =
+        tuple((distinct_parser, function_argument_parser))(i)?;
     Ok((remaining_input, (args, distinct.is_some())))
 }
 
@@ -695,12 +696,25 @@ pub fn column_function(i: &[u8]) -> IResult<&[u8], FunctionExpression> {
                 FunctionExpression::GroupConcat(FunctionArgument::Column(col.clone()), sep)
             },
         ),
-        map(tuple((sql_identifier, multispace0, tag("("), separated_list0(tag(","), delimited(multispace0, function_argument_parser, multispace0)), tag(")"))), |tuple| {
-            let (name, _, _, arguments, _) = tuple;
-            FunctionExpression::Generic(
-                str::from_utf8(name).unwrap().to_string(), 
-                FunctionArguments::from(arguments))
-        })
+        map(
+            tuple((
+                sql_identifier,
+                multispace0,
+                tag("("),
+                separated_list0(
+                    tag(","),
+                    delimited(multispace0, function_argument_parser, multispace0),
+                ),
+                tag(")"),
+            )),
+            |tuple| {
+                let (name, _, _, arguments, _) = tuple;
+                FunctionExpression::Generic(
+                    str::from_utf8(name).unwrap().to_string(),
+                    FunctionArguments::from(arguments),
+                )
+            },
+        ),
     ))(i)
 }
 
@@ -1021,22 +1035,23 @@ pub fn value_list(i: &[u8]) -> IResult<&[u8], Vec<Literal>> {
 // Parse a reference to a named schema.table, with an optional alias
 pub fn schema_table_reference(i: &[u8]) -> IResult<&[u8], Table> {
     map(
-		tuple((
-			opt(pair(sql_identifier, tag("."))),
-			sql_identifier,
-			opt(as_alias)
-		)),
-	|tup| Table {
-        name: String::from(str::from_utf8(tup.1).unwrap()),
-        alias: match tup.2 {
-            Some(a) => Some(String::from(a)),
-            None => None,
+        tuple((
+            opt(pair(sql_identifier, tag("."))),
+            sql_identifier,
+            opt(as_alias),
+        )),
+        |tup| Table {
+            name: String::from(str::from_utf8(tup.1).unwrap()),
+            alias: match tup.2 {
+                Some(a) => Some(String::from(a)),
+                None => None,
+            },
+            schema: match tup.0 {
+                Some((schema, _)) => Some(String::from(str::from_utf8(schema).unwrap())),
+                None => None,
+            },
         },
-        schema: match tup.0 {
-            Some((schema, _)) => Some(String::from(str::from_utf8(schema).unwrap())),
-            None => None,
-        },
-    })(i)
+    )(i)
 }
 
 // Parse a reference to a named table, with an optional alias
@@ -1047,7 +1062,7 @@ pub fn table_reference(i: &[u8]) -> IResult<&[u8], Table> {
             Some(a) => Some(String::from(a)),
             None => None,
         },
-		schema: None,
+        schema: None,
     })(i)
 }
 
@@ -1137,25 +1152,31 @@ mod tests {
             name: String::from("max(addr_id)"),
             alias: None,
             table: None,
-            function: Some(Box::new(FunctionExpression::Max(
-                FunctionArgument::Column(Column::from("addr_id")),
-            ))),
+            function: Some(Box::new(FunctionExpression::Max(FunctionArgument::Column(
+                Column::from("addr_id"),
+            )))),
         };
         assert_eq!(res.unwrap().1, expected);
     }
 
     #[test]
     fn simple_generic_function() {
-        let qlist = ["coalesce(a,b,c)".as_bytes(), "coalesce (a,b,c)".as_bytes(), "coalesce(a ,b,c)".as_bytes(), "coalesce(a, b,c)".as_bytes()];
+        let qlist = [
+            "coalesce(a,b,c)".as_bytes(),
+            "coalesce (a,b,c)".as_bytes(),
+            "coalesce(a ,b,c)".as_bytes(),
+            "coalesce(a, b,c)".as_bytes(),
+        ];
         for q in qlist.iter() {
             let res = column_function(q);
-            let expected = FunctionExpression::Generic("coalesce".to_string(), 
-                FunctionArguments::from(
-                    vec!(
-                        FunctionArgument::Column(Column::from("a")),
-                        FunctionArgument::Column(Column::from("b")),
-                        FunctionArgument::Column(Column::from("c"))
-                )));
+            let expected = FunctionExpression::Generic(
+                "coalesce".to_string(),
+                FunctionArguments::from(vec![
+                    FunctionArgument::Column(Column::from("a")),
+                    FunctionArgument::Column(Column::from("b")),
+                    FunctionArgument::Column(Column::from("c")),
+                ]),
+            );
             assert_eq!(res, Ok((&b""[..], expected)));
         }
     }

--- a/src/delete.rs
+++ b/src/delete.rs
@@ -1,7 +1,7 @@
 use nom::character::complete::multispace1;
 use std::{fmt, str};
 
-use common::{statement_terminator, schema_table_reference};
+use common::{schema_table_reference, statement_terminator};
 use condition::ConditionExpression;
 use keywords::escape_if_keyword;
 use nom::bytes::complete::tag_no_case;
@@ -77,7 +77,7 @@ mod tests {
         assert_eq!(
             res.unwrap().1,
             DeleteStatement {
-                table: Table::from(("db1","users")),
+                table: Table::from(("db1", "users")),
                 ..Default::default()
             }
         );

--- a/src/insert.rs
+++ b/src/insert.rs
@@ -4,7 +4,7 @@ use std::str;
 
 use column::Column;
 use common::{
-    assignment_expr_list, field_list, statement_terminator, schema_table_reference, value_list,
+    assignment_expr_list, field_list, schema_table_reference, statement_terminator, value_list,
     ws_sep_comma, FieldValueExpression, Literal,
 };
 use keywords::escape_if_keyword;
@@ -145,7 +145,7 @@ mod tests {
         assert_eq!(
             res.unwrap().1,
             InsertStatement {
-                table: Table::from(("db1","users")),
+                table: Table::from(("db1", "users")),
                 fields: None,
                 data: vec![vec![42.into(), "test".into()]],
                 ..Default::default()

--- a/src/join.rs
+++ b/src/join.rs
@@ -7,7 +7,7 @@ use nom::branch::alt;
 use nom::bytes::complete::tag_no_case;
 use nom::combinator::map;
 use nom::IResult;
-use select::{JoinClause, SelectStatement};
+use select::{JoinClause, Selection};
 use table::Table;
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
@@ -17,7 +17,7 @@ pub enum JoinRightSide {
     /// A comma-separated (and implicitly joined) sequence of tables.
     Tables(Vec<Table>),
     /// A nested selection, represented as (query, alias).
-    NestedSelect(Box<SelectStatement>, Option<String>),
+    NestedSelect(Box<Selection>, Option<String>),
     /// A nested join clause.
     NestedJoin(Box<JoinClause>),
 }
@@ -111,14 +111,14 @@ mod tests {
     use condition::ConditionBase::*;
     use condition::ConditionExpression::{self, *};
     use condition::ConditionTree;
-    use select::{selection, JoinClause, SelectStatement};
+    use select::{simple_selection, JoinClause, SelectStatement};
 
     #[test]
     fn inner_join() {
         let qstring = "SELECT tags.* FROM tags \
                        INNER JOIN taggings ON tags.id = taggings.tag_id";
 
-        let res = selection(qstring.as_bytes());
+        let res = simple_selection(qstring.as_bytes());
 
         let ct = ConditionTree {
             left: Box::new(Base(Field(Column::from("tags.id")))),

--- a/src/order.rs
+++ b/src/order.rs
@@ -82,7 +82,7 @@ pub fn order_clause(i: &[u8]) -> IResult<&[u8], OrderClause> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use select::selection;
+    use select::simple_selection;
 
     #[test]
     fn order_clause() {
@@ -103,9 +103,9 @@ mod tests {
             columns: vec![("name".into(), OrderType::OrderAscending)],
         };
 
-        let res1 = selection(qstring1.as_bytes());
-        let res2 = selection(qstring2.as_bytes());
-        let res3 = selection(qstring3.as_bytes());
+        let res1 = simple_selection(qstring1.as_bytes());
+        let res2 = simple_selection(qstring2.as_bytes());
+        let res3 = simple_selection(qstring3.as_bytes());
         assert_eq!(res1.unwrap().1.order, Some(expected_ord1));
         assert_eq!(res2.unwrap().1.order, Some(expected_ord2));
         assert_eq!(res3.unwrap().1.order, Some(expected_ord3));

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -84,6 +84,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use insert::InsertData;
     use std::collections::hash_map::DefaultHasher;
     use std::hash::{Hash, Hasher};
 
@@ -98,7 +99,7 @@ mod tests {
         let expected = SqlQuery::Insert(InsertStatement {
             table: Table::from("users"),
             fields: None,
-            data: vec![vec![42.into(), "test".into()]],
+            data: InsertData::ValueList(vec![vec![42.into(), "test".into()]]),
             ..Default::default()
         });
         let mut h0 = DefaultHasher::new();

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -84,7 +84,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use insert::InsertData;
+    use insert::{InsertData, InsertDataValue};
     use std::collections::hash_map::DefaultHasher;
     use std::hash::{Hash, Hasher};
 
@@ -99,7 +99,10 @@ mod tests {
         let expected = SqlQuery::Insert(InsertStatement {
             table: Table::from("users"),
             fields: None,
-            data: InsertData::ValueList(vec![vec![42.into(), "test".into()]]),
+            data: InsertData::ValueList(vec![vec![
+                InsertDataValue::Literal(42.into()),
+                InsertDataValue::Literal("test".into()),
+            ]]),
             ..Default::default()
         });
         let mut h0 = DefaultHasher::new();

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 use std::str;
 
-use compound_select::{compound_selection, CompoundSelectStatement};
+use compound_select::CompoundSelectStatement;
 use create::{creation, view_creation, CreateTableStatement, CreateViewStatement};
 use delete::{deletion, DeleteStatement};
 use drop::{drop_table, DropTableStatement};
@@ -9,7 +9,7 @@ use insert::{insertion, InsertStatement};
 use nom::branch::alt;
 use nom::combinator::map;
 use nom::IResult;
-use select::{selection, SelectStatement};
+use select::{selection, SelectStatement, Selection};
 use set::{set, SetStatement};
 use update::{updating, UpdateStatement};
 
@@ -42,12 +42,20 @@ impl fmt::Display for SqlQuery {
     }
 }
 
+impl From<Selection> for SqlQuery {
+    fn from(s: Selection) -> Self {
+        match s {
+            Selection::Statement(ss) => SqlQuery::Select(ss),
+            Selection::Compound(css) => SqlQuery::CompoundSelect(css),
+        }
+    }
+}
+
 pub fn sql_query(i: &[u8]) -> IResult<&[u8], SqlQuery> {
     alt((
         map(creation, |c| SqlQuery::CreateTable(c)),
         map(insertion, |i| SqlQuery::Insert(i)),
-        map(compound_selection, |cs| SqlQuery::CompoundSelect(cs)),
-        map(selection, |s| SqlQuery::Select(s)),
+        map(selection, |s| s.into()),
         map(deletion, |d| SqlQuery::Delete(d)),
         map(drop_table, |dt| SqlQuery::DropTable(dt)),
         map(updating, |u| SqlQuery::Update(u)),

--- a/src/select.rs
+++ b/src/select.rs
@@ -1,5 +1,6 @@
 use nom::character::complete::{multispace0, multispace1};
 use std::fmt;
+use std::fmt::{Display, Formatter};
 use std::str;
 
 use column::Column;
@@ -8,6 +9,7 @@ use common::{
     as_alias, field_definition_expr, field_list, statement_terminator, table_list, table_reference,
     unsigned_number,
 };
+use compound_select::nested_compound_selection;
 use condition::{condition_expr, ConditionExpression};
 use join::{join_operator, JoinConstraint, JoinOperator, JoinRightSide};
 use nom::branch::alt;
@@ -18,6 +20,7 @@ use nom::sequence::{delimited, preceded, terminated, tuple};
 use nom::IResult;
 use order::{order_clause, OrderClause};
 use table::Table;
+use CompoundSelectStatement;
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct GroupByClause {
@@ -73,6 +76,33 @@ impl fmt::Display for LimitClause {
             write!(f, " OFFSET {}", self.offset)?;
         }
         Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub enum Selection {
+    Statement(SelectStatement),
+    Compound(CompoundSelectStatement),
+}
+
+impl Display for Selection {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Statement(s) => write!(f, "{}", s),
+            Self::Compound(cs) => write!(f, "{}", cs),
+        }
+    }
+}
+
+impl From<SelectStatement> for Selection {
+    fn from(ss: SelectStatement) -> Self {
+        Self::Statement(ss)
+    }
+}
+
+impl From<CompoundSelectStatement> for Selection {
+    fn from(css: CompoundSelectStatement) -> Self {
+        Self::Compound(css)
     }
 }
 
@@ -268,12 +298,24 @@ pub fn where_clause(i: &[u8]) -> IResult<&[u8], ConditionExpression> {
     Ok((remaining_input, where_condition))
 }
 
-// Parse rule for a SQL selection query.
-pub fn selection(i: &[u8]) -> IResult<&[u8], SelectStatement> {
-    terminated(nested_selection, statement_terminator)(i)
+pub fn selection(i: &[u8]) -> IResult<&[u8], Selection> {
+    terminated(nested_selection, opt(statement_terminator))(i)
 }
 
-pub fn nested_selection(i: &[u8]) -> IResult<&[u8], SelectStatement> {
+pub fn nested_selection(i: &[u8]) -> IResult<&[u8], Selection> {
+    alt((
+        map(nested_compound_selection, |cs| Selection::Compound(cs)),
+        map(nested_simple_selection, |s| Selection::Statement(s)),
+    ))(i)
+}
+
+#[cfg(test)]
+// Parse rule for a simple SQL selection query, currently only used to simplify tests
+pub fn simple_selection(i: &[u8]) -> IResult<&[u8], SelectStatement> {
+    terminated(nested_simple_selection, statement_terminator)(i)
+}
+
+pub fn nested_simple_selection(i: &[u8]) -> IResult<&[u8], SelectStatement> {
     let (
         remaining_input,
         (_, _, distinct, _, fields, _, tables, join, where_clause, group_by, order, limit),
@@ -330,7 +372,7 @@ mod tests {
     fn simple_select() {
         let qstring = "SELECT id, name FROM users;";
 
-        let res = selection(qstring.as_bytes());
+        let res = simple_selection(qstring.as_bytes());
         assert_eq!(
             res.unwrap().1,
             SelectStatement {
@@ -345,7 +387,7 @@ mod tests {
     fn more_involved_select() {
         let qstring = "SELECT users.id, users.name FROM users;";
 
-        let res = selection(qstring.as_bytes());
+        let res = simple_selection(qstring.as_bytes());
         assert_eq!(
             res.unwrap().1,
             SelectStatement {
@@ -364,7 +406,7 @@ mod tests {
         // TODO: doesn't support selecting literals without a FROM clause, which is still valid SQL
         //        let qstring = "SELECT NULL, 1, \"foo\";";
 
-        let res = selection(qstring.as_bytes());
+        let res = simple_selection(qstring.as_bytes());
         assert_eq!(
             res.unwrap().1,
             SelectStatement {
@@ -392,7 +434,7 @@ mod tests {
     fn select_all() {
         let qstring = "SELECT * FROM users;";
 
-        let res = selection(qstring.as_bytes());
+        let res = simple_selection(qstring.as_bytes());
         assert_eq!(
             res.unwrap().1,
             SelectStatement {
@@ -407,7 +449,7 @@ mod tests {
     fn select_all_in_table() {
         let qstring = "SELECT users.* FROM users, votes;";
 
-        let res = selection(qstring.as_bytes());
+        let res = simple_selection(qstring.as_bytes());
         assert_eq!(
             res.unwrap().1,
             SelectStatement {
@@ -422,7 +464,7 @@ mod tests {
     fn spaces_optional() {
         let qstring = "SELECT id,name FROM users;";
 
-        let res = selection(qstring.as_bytes());
+        let res = simple_selection(qstring.as_bytes());
         assert_eq!(
             res.unwrap().1,
             SelectStatement {
@@ -439,8 +481,8 @@ mod tests {
         let qstring_uc = "SELECT id, name FROM users;";
 
         assert_eq!(
-            selection(qstring_lc.as_bytes()).unwrap(),
-            selection(qstring_uc.as_bytes()).unwrap()
+            simple_selection(qstring_lc.as_bytes()).unwrap(),
+            simple_selection(qstring_uc.as_bytes()).unwrap()
         );
     }
 
@@ -450,9 +492,9 @@ mod tests {
         let qstring_nosem = "select id, name from users";
         let qstring_linebreak = "select id, name from users\n";
 
-        let r1 = selection(qstring_sem.as_bytes()).unwrap();
-        let r2 = selection(qstring_nosem.as_bytes()).unwrap();
-        let r3 = selection(qstring_linebreak.as_bytes()).unwrap();
+        let r1 = simple_selection(qstring_sem.as_bytes()).unwrap();
+        let r2 = simple_selection(qstring_nosem.as_bytes()).unwrap();
+        let r3 = simple_selection(qstring_linebreak.as_bytes()).unwrap();
         assert_eq!(r1, r2);
         assert_eq!(r2, r3);
     }
@@ -482,7 +524,7 @@ mod tests {
     }
 
     fn where_clause_with_variable_placeholder(qstring: &str, literal: Literal) {
-        let res = selection(qstring.as_bytes());
+        let res = simple_selection(qstring.as_bytes());
 
         let expected_left = Base(Field(Column::from("email")));
         let expected_where_cond = Some(ComparisonOp(ConditionTree {
@@ -515,8 +557,8 @@ mod tests {
             offset: 10,
         };
 
-        let res1 = selection(qstring1.as_bytes());
-        let res2 = selection(qstring2.as_bytes());
+        let res1 = simple_selection(qstring1.as_bytes());
+        let res2 = simple_selection(qstring2.as_bytes());
         assert_eq!(res1.unwrap().1.limit, Some(expected_lim1));
         assert_eq!(res2.unwrap().1.limit, Some(expected_lim2));
     }
@@ -526,14 +568,14 @@ mod tests {
         let qstring1 = "select * from PaperTag as t;";
         // let qstring2 = "select * from PaperTag t;";
 
-        let res1 = selection(qstring1.as_bytes());
+        let res1 = simple_selection(qstring1.as_bytes());
         assert_eq!(
             res1.unwrap().1,
             SelectStatement {
                 tables: vec![Table {
                     name: String::from("PaperTag"),
                     alias: Some(String::from("t")),
-					schema: None,
+                    schema: None,
                 },],
                 fields: vec![FieldDefinitionExpression::All],
                 ..Default::default()
@@ -547,14 +589,14 @@ mod tests {
     fn table_schema() {
         let qstring1 = "select * from db1.PaperTag as t;";
 
-        let res1 = selection(qstring1.as_bytes());
+        let res1 = simple_selection(qstring1.as_bytes());
         assert_eq!(
             res1.unwrap().1,
             SelectStatement {
                 tables: vec![Table {
                     name: String::from("PaperTag"),
                     alias: Some(String::from("t")),
-					schema: Some(String::from("db1")),
+                    schema: Some(String::from("db1")),
                 },],
                 fields: vec![FieldDefinitionExpression::All],
                 ..Default::default()
@@ -569,7 +611,7 @@ mod tests {
         let qstring1 = "select name as TagName from PaperTag;";
         let qstring2 = "select PaperTag.name as TagName from PaperTag;";
 
-        let res1 = selection(qstring1.as_bytes());
+        let res1 = simple_selection(qstring1.as_bytes());
         assert_eq!(
             res1.unwrap().1,
             SelectStatement {
@@ -583,7 +625,7 @@ mod tests {
                 ..Default::default()
             }
         );
-        let res2 = selection(qstring2.as_bytes());
+        let res2 = simple_selection(qstring2.as_bytes());
         assert_eq!(
             res2.unwrap().1,
             SelectStatement {
@@ -604,7 +646,7 @@ mod tests {
         let qstring1 = "select name TagName from PaperTag;";
         let qstring2 = "select PaperTag.name TagName from PaperTag;";
 
-        let res1 = selection(qstring1.as_bytes());
+        let res1 = simple_selection(qstring1.as_bytes());
         assert_eq!(
             res1.unwrap().1,
             SelectStatement {
@@ -618,7 +660,7 @@ mod tests {
                 ..Default::default()
             }
         );
-        let res2 = selection(qstring2.as_bytes());
+        let res2 = simple_selection(qstring2.as_bytes());
         assert_eq!(
             res2.unwrap().1,
             SelectStatement {
@@ -638,7 +680,7 @@ mod tests {
     fn distinct() {
         let qstring = "select distinct tag from PaperTag where paperId=?;";
 
-        let res = selection(qstring.as_bytes());
+        let res = simple_selection(qstring.as_bytes());
         let expected_left = Base(Field(Column::from("paperId")));
         let expected_where_cond = Some(ComparisonOp(ConditionTree {
             left: Box::new(expected_left),
@@ -663,7 +705,7 @@ mod tests {
     fn simple_condition_expr() {
         let qstring = "select infoJson from PaperStorage where paperId=? and paperStorageId=?;";
 
-        let res = selection(qstring.as_bytes());
+        let res = simple_selection(qstring.as_bytes());
 
         let left_ct = ConditionTree {
             left: Box::new(Base(Field(Column::from("paperId")))),
@@ -700,7 +742,7 @@ mod tests {
     #[test]
     fn where_and_limit_clauses() {
         let qstring = "select * from users where id = ? limit 10\n";
-        let res = selection(qstring.as_bytes());
+        let res = simple_selection(qstring.as_bytes());
 
         let expected_lim = Some(LimitClause {
             limit: 10,
@@ -731,7 +773,7 @@ mod tests {
     fn aggregation_column() {
         let qstring = "SELECT max(addr_id) FROM address;";
 
-        let res = selection(qstring.as_bytes());
+        let res = simple_selection(qstring.as_bytes());
         let agg_expr = FunctionExpression::Max(FunctionArgument::Column(Column::from("addr_id")));
         assert_eq!(
             res.unwrap().1,
@@ -752,7 +794,7 @@ mod tests {
     fn aggregation_column_with_alias() {
         let qstring = "SELECT max(addr_id) AS max_addr FROM address;";
 
-        let res = selection(qstring.as_bytes());
+        let res = simple_selection(qstring.as_bytes());
         let agg_expr = FunctionExpression::Max(FunctionArgument::Column(Column::from("addr_id")));
         let expected_stmt = SelectStatement {
             tables: vec![Table::from("address")],
@@ -771,7 +813,7 @@ mod tests {
     fn count_all() {
         let qstring = "SELECT COUNT(*) FROM votes GROUP BY aid;";
 
-        let res = selection(qstring.as_bytes());
+        let res = simple_selection(qstring.as_bytes());
         let agg_expr = FunctionExpression::CountStar;
         let expected_stmt = SelectStatement {
             tables: vec![Table::from("votes")],
@@ -794,7 +836,7 @@ mod tests {
     fn count_distinct() {
         let qstring = "SELECT COUNT(DISTINCT vote_id) FROM votes GROUP BY aid;";
 
-        let res = selection(qstring.as_bytes());
+        let res = simple_selection(qstring.as_bytes());
         let agg_expr =
             FunctionExpression::Count(FunctionArgument::Column(Column::from("vote_id")), true);
         let expected_stmt = SelectStatement {
@@ -818,7 +860,7 @@ mod tests {
     fn count_filter() {
         let qstring =
             "SELECT COUNT(CASE WHEN vote_id > 10 THEN vote_id END) FROM votes GROUP BY aid;";
-        let res = selection(qstring.as_bytes());
+        let res = simple_selection(qstring.as_bytes());
 
         let filter_cond = ComparisonOp(ConditionTree {
             left: Box::new(Base(Field(Column::from("vote_id")))),
@@ -854,7 +896,7 @@ mod tests {
     fn sum_filter() {
         let qstring = "SELECT SUM(CASE WHEN sign = 1 THEN vote_id END) FROM votes GROUP BY aid;";
 
-        let res = selection(qstring.as_bytes());
+        let res = simple_selection(qstring.as_bytes());
 
         let filter_cond = ComparisonOp(ConditionTree {
             left: Box::new(Base(Field(Column::from("sign")))),
@@ -891,7 +933,7 @@ mod tests {
         let qstring =
             "SELECT SUM(CASE WHEN sign = 1 THEN vote_id ELSE 6 END) FROM votes GROUP BY aid;";
 
-        let res = selection(qstring.as_bytes());
+        let res = simple_selection(qstring.as_bytes());
 
         let filter_cond = ComparisonOp(ConditionTree {
             left: Box::new(Base(Field(Column::from("sign")))),
@@ -930,7 +972,7 @@ mod tests {
             FROM votes
             GROUP BY votes.comment_id;";
 
-        let res = selection(qstring.as_bytes());
+        let res = simple_selection(qstring.as_bytes());
 
         let filter_cond = LogicalOp(ConditionTree {
             left: Box::new(ComparisonOp(ConditionTree {
@@ -974,7 +1016,7 @@ mod tests {
     fn generic_function_query() {
         let qstring = "SELECT coalesce(a, b,c) as x,d FROM sometable;";
 
-        let res = selection(qstring.as_bytes());
+        let res = simple_selection(qstring.as_bytes());
         let agg_expr = FunctionExpression::Generic(
             String::from("coalesce"),
             FunctionArguments {
@@ -1026,7 +1068,7 @@ mod tests {
         let qstring = "SELECT * FROM item, author WHERE item.i_a_id = author.a_id AND \
                        item.i_subject = ? ORDER BY item.i_title limit 50;";
 
-        let res = selection(qstring.as_bytes());
+        let res = simple_selection(qstring.as_bytes());
         let expected_where_cond = Some(LogicalOp(ConditionTree {
             left: Box::new(ComparisonOp(ConditionTree {
                 left: Box::new(Base(Field(Column::from("item.i_a_id")))),
@@ -1064,7 +1106,7 @@ mod tests {
     fn simple_joins() {
         let qstring = "select paperId from PaperConflict join PCMember using (contactId);";
 
-        let res = selection(qstring.as_bytes());
+        let res = simple_selection(qstring.as_bytes());
         let expected_stmt = SelectStatement {
             tables: vec![Table::from("PaperConflict")],
             fields: columns(&["paperId"]),
@@ -1086,7 +1128,7 @@ mod tests {
                        join PaperReview on (PCMember.contactId=PaperReview.contactId) \
                        order by contactId;";
 
-        let res = selection(qstring.as_bytes());
+        let res = simple_selection(qstring.as_bytes());
         let ct = ConditionTree {
             left: Box::new(Base(Field(Column::from("PCMember.contactId")))),
             right: Box::new(Base(Field(Column::from("PaperReview.contactId")))),
@@ -1113,7 +1155,7 @@ mod tests {
                        from PCMember \
                        join PaperReview on PCMember.contactId=PaperReview.contactId \
                        order by contactId;";
-        let res = selection(qstring.as_bytes());
+        let res = simple_selection(qstring.as_bytes());
         assert_eq!(res.unwrap().1, expected);
     }
 
@@ -1133,7 +1175,7 @@ mod tests {
                        (contactId) left join ChairAssistant using (contactId) left join Chair \
                        using (contactId) where ContactInfo.contactId=?;";
 
-        let res = selection(qstring.as_bytes());
+        let res = simple_selection(qstring.as_bytes());
         let ct = ConditionTree {
             left: Box::new(Base(Field(Column::from("ContactInfo.contactId")))),
             right: Box::new(Base(Literal(Literal::Placeholder(
@@ -1177,7 +1219,7 @@ mod tests {
                     WHERE orders.o_c_id IN (SELECT o_c_id FROM orders, order_line \
                     WHERE orders.o_id = order_line.ol_o_id);";
 
-        let res = selection(qstr.as_bytes());
+        let res = simple_selection(qstr.as_bytes());
         let inner_where_clause = ComparisonOp(ConditionTree {
             left: Box::new(Base(Field(Column::from("orders.o_id")))),
             right: Box::new(Base(Field(Column::from("order_line.ol_o_id")))),
@@ -1214,7 +1256,7 @@ mod tests {
                     WHERE orders.o_id = order_line.ol_o_id \
                     AND orders.o_id > (SELECT MAX(o_id) FROM orders));";
 
-        let res = selection(qstr.as_bytes());
+        let res = simple_selection(qstr.as_bytes());
 
         let agg_expr = FunctionExpression::Max(FunctionArgument::Column(Column::from("o_id")));
         let recursive_select = SelectStatement {
@@ -1286,7 +1328,7 @@ mod tests {
         let qstr_with_alias = "SELECT o_id, ol_i_id FROM orders JOIN \
                                (SELECT ol_i_id FROM order_line) AS ids \
                                ON (orders.o_id = ids.ol_i_id);";
-        let res = selection(qstr_with_alias.as_bytes());
+        let res = simple_selection(qstr_with_alias.as_bytes());
 
         // N.B.: Don't alias the inner select to `inner`, which is, well, a SQL keyword!
         let inner_select = SelectStatement {
@@ -1300,7 +1342,10 @@ mod tests {
             fields: columns(&["o_id", "ol_i_id"]),
             join: vec![JoinClause {
                 operator: JoinOperator::Join,
-                right: JoinRightSide::NestedSelect(Box::new(inner_select), Some("ids".into())),
+                right: JoinRightSide::NestedSelect(
+                    Box::new(inner_select.into()),
+                    Some("ids".into()),
+                ),
                 constraint: JoinConstraint::On(ComparisonOp(ConditionTree {
                     operator: Operator::Equal,
                     left: Box::new(Base(Field(Column::from("orders.o_id")))),
@@ -1340,7 +1385,7 @@ mod tests {
             ..Default::default()
         };
 
-        assert_eq!(res.unwrap().1, expected);
+        assert_eq!(res.unwrap().1, expected.into());
     }
 
     #[test]
@@ -1370,7 +1415,7 @@ mod tests {
             ..Default::default()
         };
 
-        assert_eq!(res.unwrap().1, expected);
+        assert_eq!(res.unwrap().1, expected.into());
     }
 
     #[test]
@@ -1407,6 +1452,6 @@ mod tests {
             ..Default::default()
         };
 
-        assert_eq!(res.unwrap().1, expected);
+        assert_eq!(res.unwrap().1, expected.into());
     }
 }

--- a/src/update.rs
+++ b/src/update.rs
@@ -72,8 +72,8 @@ mod tests {
     use condition::ConditionBase::*;
     use condition::ConditionExpression::*;
     use condition::ConditionTree;
-    use FieldValueExpression;
     use table::Table;
+    use FieldValueExpression;
 
     #[test]
     fn simple_update() {
@@ -89,13 +89,15 @@ mod tests {
                 fields: vec![
                     (
                         Column::from("id"),
-                        FieldValueExpression::Literal(LiteralExpression::from(Literal::from(42))).into(),
+                        FieldValueExpression::Literal(LiteralExpression::from(Literal::from(42)))
+                            .into(),
                     ),
                     (
                         Column::from("name"),
                         FieldValueExpression::Literal(LiteralExpression::from(Literal::from(
                             "test",
-                        ))).into(),
+                        )))
+                        .into(),
                     ),
                 ],
                 ..Default::default()
@@ -106,14 +108,8 @@ mod tests {
             UpdateStatement {
                 table: Table::from("users"),
                 fields: vec![
-                    (
-                        Column::from("id"),
-                        Column::from("new_id").into(),
-                    ),
-                    (
-                        Column::from("name"),
-                        Column::from("old_name").into(),
-                    ),
+                    (Column::from("id"), Column::from("new_id").into(),),
+                    (Column::from("name"), Column::from("old_name").into(),),
                 ],
                 ..Default::default()
             }
@@ -138,13 +134,15 @@ mod tests {
                 fields: vec![
                     (
                         Column::from("id"),
-                        FieldValueExpression::Literal(LiteralExpression::from(Literal::from(42))).into(),
+                        FieldValueExpression::Literal(LiteralExpression::from(Literal::from(42)))
+                            .into(),
                     ),
                     (
                         Column::from("name"),
                         FieldValueExpression::Literal(LiteralExpression::from(Literal::from(
                             "test",
-                        ))).into(),
+                        )))
+                        .into(),
                     ),
                 ],
                 where_clause: expected_where_cond,
@@ -185,7 +183,8 @@ mod tests {
                             integral: -19216,
                             fractional: 5479744,
                         }
-                    ),)).into(),
+                    ),))
+                    .into(),
                 ),],
                 where_clause: expected_where_cond,
                 ..Default::default()

--- a/tests/exists-queries.txt
+++ b/tests/exists-queries.txt
@@ -3,4 +3,5 @@ SELECT * FROM employees e WHERE exists(SELECT id FROM eotm_dyn d WHERE d.employe
 SELECT * FROM employees e WHERE not exists ( SELECT id FROM eotm_dyn d WHERE d.employeeID = e.id)
 SELECT * FROM employees e WHERE not (exists ( SELECT id FROM eotm_dyn d WHERE d.employeeID = e.id))
 SELECT * FROM employees e WHERE x > 3 and not exists (SELECT id FROM eotm_dyn d WHERE d.employeeID = e.id ) and y < 3
+SELECT * FROM employees e WHERE x > 3 and not exists (SELECT id FROM eotm_dyn d WHERE d.employeeID = e.id UNION SELECT id FROM eotm_dyn d WHERE d.employeeID IS NULL ) and y < 3
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -131,7 +131,7 @@ fn exists_test_queries() {
     );
     assert!(res.is_ok());
     // There are 4 queries
-    assert_eq!(res.unwrap(), 4);
+    assert_eq!(res.unwrap(), 5);
 }
 
 #[test]
@@ -198,6 +198,14 @@ fn parse_comments() {
 
     // There are 2 CREATE TABLE queries in the schema
     assert_eq!(ok, 2);
+    assert_eq!(fail, 0);
+}
+
+#[test]
+fn parse_nested_compound_selects() {
+    let (ok, fail) = parse_file("tests/nested-compound-selects.txt");
+
+    assert_eq!(ok, 4);
     assert_eq!(fail, 0);
 }
 

--- a/tests/nested-compound-selects.txt
+++ b/tests/nested-compound-selects.txt
@@ -1,0 +1,5 @@
+SELECT a, b FROM table1 JOIN (SELECT c, d FROM table2 WHERE c = d UNION SELECT a, b FROM table 3 WHERE a = b);
+SELECT c, d FROM table2 WHERE c = d UNION SELECT a, b FROM table3 WHERE a = b UNION SELECT c, d FROM table2 WHERE c = d UNION SELECT a, b FROM table3 WHERE a = b;
+(SELECT c, d FROM table2 WHERE c = d UNION SELECT a, b FROM table3 WHERE a = b UNION SELECT c, d FROM table2 WHERE c = d UNION SELECT a, b FROM table3 WHERE a = b) UNION ALL (SELECT c, d FROM table2 WHERE c = d UNION SELECT a, b FROM table3 WHERE a = b UNION SELECT c, d FROM table2 WHERE c = d UNION SELECT a, b FROM table3 WHERE a = b);
+SELECT a, b FROM table1 WHERE a IN (SELECT c FROM table2 WHERE c = d UNION SELECT b FROM table3 WHERE a > b);
+


### PR DESCRIPTION
This change addresses the improvements to the insertion parser mentioned in https://github.com/ms705/nom-sql/issues/76. This allows parsing for ON DUPLICATE column = column, DEFAULT and DEFAULT(col) in the VALUES() list, the ROW() method inside of a VALUES() list and INSERT...SELECT, including compound queries.